### PR TITLE
Feature/#90 日記を編集・削除する機能

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,6 @@ RUN apt-get update -qq && \
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential git libpq-dev libvips pkg-config
 
-RUN yarn cache clean && yarn add react react-dom
-RUN yarn add @supabase/supabase-js
-RUN yarn add @types/react @types/react-dom @types/node
-RUN yarn add -D dotenv
-
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -1,6 +1,7 @@
 class DiariesController < ApplicationController
   before_action :require_login
-  before_action :check_family, only: [:index, :show, :new, :create]
+  before_action :set_diary, only: [:edit, :update, :destroy]
+  before_action :check_family, only: [:index, :show, :new, :create, :edit, :udate, :destroy]
   
   def index
     @diaries = current_user.family.diaries.order(date: :desc)
@@ -20,7 +21,7 @@ class DiariesController < ApplicationController
     @diary = Diary.new(diary_params)
     @diary.user_id = current_user.id
     if @diary.save
-      redirect_to root_path, notice: '日記を投稿しました！'
+      redirect_to root_path, notice: '日記を投稿しました。'
     else
       @children = Child.where(family_id: current_user.family_id)
       @emojis = Emoji.all
@@ -29,10 +30,37 @@ class DiariesController < ApplicationController
     end
   end
 
+  def edit
+    @children = Child.where(family_id: current_user.family_id)
+    @emojis = Emoji.all
+  end
+
+  def update
+    if @diary.update(diary_params)
+      redirect_to diaries_path, notice: '日記を更新しました。'
+    else
+      @children = Child.where(family_id: current_user.family_id)
+      @emojis = Emoji.all
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @diary.destroy
+    redirect_to diaries_path, notice: '日記を削除しました。', status: :see_other
+  end
+
   private
 
   def diary_params
     params.require(:diary).permit(:date, :emoji_id, :body)
+  end
+
+  def set_diary
+    # 他人の日記を編集できないよう、current_userから辿る
+    @diary = current_user.diaries.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to diaries_path, alert: '指定された日記が見つからないか、編集権限がありません。'
   end
 
   def check_family

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -33,6 +33,7 @@ class DiariesController < ApplicationController
   def edit
     @children = Child.where(family_id: current_user.family_id)
     @emojis = Emoji.all
+    @emoji = @diary.emoji
   end
 
   def update

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -1,7 +1,7 @@
 class DiariesController < ApplicationController
   before_action :require_login
   before_action :set_diary, only: [:edit, :update, :destroy]
-  before_action :check_family, only: [:index, :show, :new, :create, :edit, :udate, :destroy]
+  before_action :check_family, only: [:index, :show, :new, :create, :edit, :update, :destroy]
   
   def index
     @diaries = current_user.family.diaries.order(date: :desc)

--- a/app/views/diaries/edit.html.erb
+++ b/app/views/diaries/edit.html.erb
@@ -41,6 +41,6 @@
   </div>
 
   <div class="text-center">
-    <%= button_to "削除する", root_path, method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
+    <%= button_to "削除する", diary_path(@diary), data: { turbo_method: :delete, turbo_confirm: '本当にこの日記を削除しますか？' }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
   </div>
 </div>

--- a/app/views/diaries/edit.html.erb
+++ b/app/views/diaries/edit.html.erb
@@ -2,7 +2,7 @@
   <h1 class="text-3xl font-bold m-6">日記を編集</h1>
 
   <div id="diary_edit_form">
-    <%= form_with model: @diary, url: diary_path, local: true do |f| %>
+    <%= form_with model: @diary, url: diary_path(diary_id: @diary.id), local: true do |f| %>
     <div class="my-4">
       <div>
         <%= f.label :date, "日付", class: "font-bold" %>
@@ -16,14 +16,14 @@
         <%= f.label :child_id, "どの子？", class: "font-bold" %>
       </div>
       <div>
-        <!-- %= f.select :child_id, options_from_collection_for_select(@children, :id, :name), include_blank: "選択してください", class: "border border-default-medium rounded-base" % -->
+        <!-- %= f.select :child_id, options_from_collection_for_select(@children, :id, :name, { :selected => @child.id }), include_blank: "選択してください", class: "border border-default-medium rounded-base" % -->
       </div>
     </div>
     <div class="my-4">
         <%= f.label :emoji_id, "絵文字", class: "font-bold" %>
       </div>
       <div>
-        <%= f.select :emoji_id, options_from_collection_for_select(@emojis, :id, :character), include_blank: "選択してください", class: "border border-default-medium rounded-base" %>
+        <%= f.select :emoji_id, options_from_collection_for_select(@emojis, :id, :character, { :selected => @emoji.id }), include_blank: "選択してください", class: "border border-default-medium rounded-base" %>
       </div>
     </div>
     <div class="my-4">
@@ -41,6 +41,6 @@
   </div>
 
   <div class="text-center">
-    <%= button_to "削除する", diary_path(@diary), data: { turbo_method: :delete, turbo_confirm: '本当にこの日記を削除しますか？' }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
+    <%= button_to "削除する", diary_path(@diary.id), method: :delete, data: { turbo_confirm: '本当にこの日記を削除しますか？' }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
   </div>
 </div>

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -40,7 +40,7 @@
                 <%= button_to "編集", edit_diary_path(diary_id: @diary.id), method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
               </div>
               <div class="flex-auto">
-                <%= button_to "削除", diary_path(@diary), data: { turbo_method: :delete, turbo_confirm: '本当にこの日記を削除しますか？' }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
+                <%= button_to "削除", diary_path(@diary.id), method: :delete, data: { turbo_method: :delete, turbo_confirm: '本当にこの日記を削除しますか？' }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
               </div>
           </td>
         </tr>

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -40,7 +40,7 @@
                 <%= button_to "編集", edit_diary_path(diary_id: @diary.id), method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
               </div>
               <div class="flex-auto">
-                <%= button_to "削除", edit_diary_path(diary_id: @diary.id), method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
+                <%= button_to "削除", diary_path(@diary), data: { turbo_method: :delete, turbo_confirm: '本当にこの日記を削除しますか？' }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
               </div>
           </td>
         </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :diaries, only: [:index, :show, :new, :create]
+  resources :diaries
     
   # APIエンドポイントの定義
   namespace :api do


### PR DESCRIPTION
## 概要
日記を編集・削除する機能を実装

## 関連issue
#90 

## やったこと
 - ルーティングの設定
 - コントローラーファイルに`edit`・`update`・`destroy`アクションを追加
 - `set_diary`を定義（編集・削除対象のDiaryを設定する）
 - `before_action`で`set_diary`を指定（`edit`、`update`、`destroy`のみ対象）

## テスト／完了確認
 - [x] 投稿した日記を編集できることを確認
 - [x] 投稿した日記を`show`ページからでも`edit`ページからでも削除できることを確認
 - [x] 自分の投稿した日記以外は編集・削除ができないことを確認
 - [x] 家族に所属していなければ、日記の操作や閲覧に関する機能にアクセスできないことを確認

## 備考
本番環境用のDockerfileの記述を少し修正