### PR TITLE
Feature/#91 カレンダー表示画面を作成

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,15 @@ ENV RAILS_ENV="production" \
     BUNDLE_PATH="/usr/local/bundle" \
     BUNDLE_WITHOUT="development"
 
-
 # Throw-away build stage to reduce size of final image
 FROM base as build
 
+# Node.js 20 (LTS) をインストールする
 RUN apt-get update -qq && \
-    apt-get install -y nodejs npm && npm install -g yarn
-
-# Install packages needed to build gems
-RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git libpq-dev libvips pkg-config
+    apt-get install -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    npm install -g yarn
 
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,8 @@ gem 'config', '~> 5.6'
 
 gem 'resend', '~> 0.10.0'
 
+gem 'simple_calendar', '~> 3.1.0'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,6 +333,8 @@ GEM
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
     shellany (0.0.1)
+    simple_calendar (3.1.0)
+      rails (>= 6.1)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -393,6 +395,7 @@ DEPENDENCIES
   rails (~> 7.1.6)
   resend (~> 0.10.0)
   selenium-webdriver
+  simple_calendar (~> 3.1.0)
   sprockets-rails
   stimulus-rails
   supabase (~> 0.1.0)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,3 +2,4 @@
 //= link_tree ../builds
 //= link_directory ../../javascript/controllers .js
 //= link_tree ../../../vendor/javascript .js
+//= link simple_calendar.css

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -1,7 +1,21 @@
 <div id="diary_index" class="text-center">
   <h1 class="text-3xl font-bold m-6">日記一覧</h1>
 
-  <div id="diary_list">
+  <div id="diary_calendar" class="mx-4 my-8">
+    <div class="text-center">
+      <%= month_calendar(attribute: :date, events: @diaries) do |date, diary| %>
+        <%= date.day %>
+
+        <% diary.each do |d| %>
+          <div>
+            <%= link_to d.emoji.character, diary_path(d.id) %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+
+  <div id="diary_list" class="m-8">
     <table class="mx-auto border-collapse border">
       <tbody>
         <tr>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", "simple_calendar", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>

--- a/app/views/simple_calendar/_calendar.html.erb
+++ b/app/views/simple_calendar/_calendar.html.erb
@@ -1,0 +1,33 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <span class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>
+
+    <nav>
+      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
+      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    </nav>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <%= content_tag :tr, class: calendar.tr_classes_for(week) do %>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,0 +1,33 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <time datetime="<%= start_date.strftime('%Y-%m') %>" class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></time>
+
+    <nav>
+      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
+      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    </nav>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <tr>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,11 +1,31 @@
 <div class="simple-calendar">
   <div class="calendar-heading">
-    <time datetime="<%= start_date.strftime('%Y-%m') %>" class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></time>
-
     <nav>
-      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
-      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
-      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+      <div class="flex justify-center">
+        <div class="px-2">
+          <%= link_to t('simple_calendar.lastYear', default: 'LastYear'), url_for(params.permit(:start_date).to_h.merge(start_date: start_date.beginning_of_month - 1.year)) %>
+        </div>
+        <div class="px-2">
+          <span class="calendar-title"><%= start_date.year %> <%= t('date.year') %></span>
+        </div>
+        <div class="px-2">
+          <%= link_to t('simple_calendar.following', default: 'Following'), url_for(params.permit(:start_date).to_h.merge(start_date: start_date.beginning_of_month + 1.year)) %>
+        </div>
+      </div>
+      <div>
+        <time datetime="<%= start_date.strftime('%Y-%m') %>" class="calendar-title"><%= t('date.month_names')[start_date.month] %></time>
+      </div>
+      <div class="flex justify-center">
+        <div class="px-2">
+          <%= link_to t('simple_calendar.previous', default: 'Previous'), url_for(params.permit(:start_date).to_h.merge(start_date: start_date.beginning_of_month - 1.month)) %>
+        </div>
+        <div class="px-2">
+          <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
+        </div>
+        <div class="px-2">
+          <%= link_to t('simple_calendar.next', default: 'Next'), url_for(params.permit(:start_date).to_h.merge(start_date: start_date.beginning_of_month + 1.month)) %>
+        </div>
+      </div>
     </nav>
   </div>
 

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -12,19 +12,19 @@
           <%= link_to t('simple_calendar.following', default: 'Following'), url_for(params.permit(:start_date).to_h.merge(start_date: start_date.beginning_of_month + 1.year)) %>
         </div>
       </div>
-      <div>
-        <time datetime="<%= start_date.strftime('%Y-%m') %>" class="calendar-title"><%= t('date.month_names')[start_date.month] %></time>
-      </div>
       <div class="flex justify-center">
         <div class="px-2">
           <%= link_to t('simple_calendar.previous', default: 'Previous'), url_for(params.permit(:start_date).to_h.merge(start_date: start_date.beginning_of_month - 1.month)) %>
         </div>
         <div class="px-2">
-          <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
+          <time datetime="<%= start_date.strftime('%Y-%m') %>" class="calendar-title"><%= t('date.month_names')[start_date.month] %></time>
         </div>
         <div class="px-2">
           <%= link_to t('simple_calendar.next', default: 'Next'), url_for(params.permit(:start_date).to_h.merge(start_date: start_date.beginning_of_month + 1.month)) %>
         </div>
+      </div>
+      <div>
+        <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
       </div>
     </nav>
   </div>
@@ -33,7 +33,7 @@
     <thead>
       <tr>
         <% date_range.slice(0, 7).each do |day| %>
-          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+          <th><p class="text-center"><%= t('date.abbr_day_names')[day.wday] %></p></th>
         <% end %>
       </tr>
     </thead>

--- a/app/views/simple_calendar/_week_calendar.html.erb
+++ b/app/views/simple_calendar/_week_calendar.html.erb
@@ -1,0 +1,39 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <span class="calendar-title">
+      <%= t('simple_calendar.week', default: 'Week') %>
+      <%= calendar.week_number %>
+      <% if calendar.number_of_weeks > 1 %>
+        - <%= calendar.end_week %>
+      <% end %>
+    </span>
+
+    <nav>
+      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
+      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    </nav>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <tr>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,28 +2,16 @@ require_relative "boot"
 
 require "rails/all"
 
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 module App
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
 
-    # Please, add to the `ignore` list any other `lib` subdirectories that do
-    # not contain `.rb` files, or that should not be reloaded or eager loaded.
-    # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w(assets tasks))
-
-    # Configuration for the application, engines, and railties goes here.
-    #
-    # These settings can be overridden in specific environments using the files
-    # in config/environments, which are processed later.
-    #
     config.time_zone = "Asia/Tokyo"
     config.active_record.default_timezone = :local
     config.i18n.default_locale = :ja
-    # config.eager_load_paths << Rails.root.join("extras")
+    
+    config.beginning_of_week = :sunday
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,7 +3,10 @@ ja:
     previous: "<<"
     next: ">>"
     today: "今日"
+    lastYear: "<"
+    following: ">"
   date:
+    year: "年"
     abbr_day_names:
       - 日
       - 月

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,2 +1,54 @@
 ja:
-  hello: "こんにちは"
+  simple_calendar:
+    previous: "<<"
+    next: ">>"
+    today: "今日"
+  date:
+    abbr_day_names:
+      - 日
+      - 月
+      - 火
+      - 水
+      - 木
+      - 金
+      - 土
+    abbr_month_names:
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+    day_names:
+      - 日曜日
+      - 月曜日
+      - 火曜日
+      - 水曜日
+      - 木曜日
+      - 金曜日
+      - 土曜日
+    formats:
+      default: "%Y/%m/%d(%a)"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月


### PR DESCRIPTION
## 概要
カレンダーを表示する画面を作成

## 関連issue
#91 

## やったこと
 - Gem `simple_calendar`を導入
 - 月カレンダーのカスタムビューを利用
 - 月カレンダーの表示を調整
 - `diaries/index`に月カレンダーを表示
 - 日付と対応している日記の絵文字を出力し、日記詳細ページへのリンクを追加

## やらないこと
 - `diaries/index`ページの日記一覧を削除する

## テスト／完了確認
 - [x] カレンダーが表示されることを確認
 	- [x] 今月のカレンダーが表示
 	- [x] 月の移動ができる
 	- [x] 年の移動ができる

## 備考
 - Dockerfile：Node.js 20を明示的にインストールするコマンドに変更