### PR TITLE
Feature/#92 1日ごとの日記一覧ページを作成

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,11 +35,13 @@ RUN bundle install && \
 # Copy application code
 COPY . .
 
+RUN chmod +x bin/*
+
 # Precompile bootsnap code for faster boot times
 RUN bundle exec bootsnap precompile app/ lib/
 
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+RUN SECRET_KEY_BASE_DUMMY=1 NODE_OPTIONS="--max-old-space-size=448" ./bin/rails assets:precompile
 
 
 # Final stage for app image

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM base as build
 
 # Node.js 20 (LTS) をインストールする
 RUN apt-get update -qq && \
-    apt-get install -y curl && \
+    apt-get install -y curl build-essential git libpq-dev libvips pkg-config && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs && \
     npm install -g yarn

--- a/app/views/diaries/date_index.html.erb
+++ b/app/views/diaries/date_index.html.erb
@@ -1,0 +1,43 @@
+<div id="date_index" class="text-center">
+  <h1 class="text-3xl font-bold m-6"><%= l(@date.to_date, format: :long) %>の日記</h1>
+
+  <% if @diaries.any? %>
+    <div id="diary" class="w-2/3 justify-self-center">
+      <% @diaries.each do |diary| %>
+        <div class="flex flex-col m-4 border rounded-md">
+          <%# 1段目：絵文字（左寄せ） %>
+          <div class="flex justify-start p-4">
+            <%= diary.emoji.character %>
+          </div>
+
+          <%# 2段目：カテゴリ、タグ %>
+          <div class="flex justify-start gap-2 px-6">
+            <div class="border p-2">カテゴリ</div>
+            <div class="border p-2">タグ</div>
+          </div>
+
+          <%# 3段目：ID、家族ID、家族名、ユーザー名 %>
+          <div class="flex justify-center m-2">
+            <div class="p-2">id：<%= diary.id %></div>
+            <div class="p-2">family_id：<%= diary.user.family_id %></div>
+            <div class="p-2">family name：<%= diary.user.family.name %></div>
+            <div class="p-2">user：<%= diary.user.name %></div>
+          </div>
+
+          <%# 4段目：本文 %>
+          <div class="flex justify-start m-2 px-4 py-2">
+            <%= diary.body %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <div>
+      <p>日記はありません。</p>
+    </div>
+  <% end %>
+
+  <div class="my-8">
+    <%= link_to "カレンダーに戻る", diaries_path %>
+  </div>
+</div>


### PR DESCRIPTION
## 概要
日付（1日）ごとの日記一覧を表示するページを作成

## 関連issue
#92 

## やったこと
 - 1日ごとの日記一覧ページ `diaries/date_index` を作成

## やらないこと
 - ルーティングの設定
 - コントローラーの設定
 - カレンダーの日付に、1日ごとの日記一覧ページへのリンクを追加

## テスト／完了確認
 - [x] ルーティングやコントローラーの設定をし、1日ごとの日記一覧ページにアクセスして表示を確認する
 - [x] 画面遷移図に基づいた構成になっていることを確認

## 備考
 - Dockerfile
	 - ビルド用パッケージを追加（build-essentialなど）
	 - 実行権限を付与
	 -メモリ制限付きのプリコンパイルにする