### PR TITLE
Feature/#96 DiaryChildモデルとdiary_childrenテーブルを作成

### DIFF
--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -1,6 +1,9 @@
 class Child < ApplicationRecord
   belongs_to :family
 
+  has_many :diary_children, dependent: :destroy
+  has_many :diaries, through: :diary_children
+
   validates :name, presence: true
   validates :birthday, presence: true
 end

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -1,6 +1,9 @@
 class Diary < ApplicationRecord
   belongs_to :user
   belongs_to :emoji
+
+  has_many :diary_children, dependent: :destroy
+  has_many :children, through: :diary_children
   
   validates :date, :body, presence: true
 end

--- a/app/models/diary_child.rb
+++ b/app/models/diary_child.rb
@@ -1,0 +1,4 @@
+class DiaryChild < ApplicationRecord
+  belongs_to :diary
+  belongs_to :child
+end

--- a/db/migrate/20251224071536_create_diary_children.rb
+++ b/db/migrate/20251224071536_create_diary_children.rb
@@ -1,0 +1,10 @@
+class CreateDiaryChildren < ActiveRecord::Migration[7.1]
+  def change
+    create_table :diary_children do |t|
+      t.references :diary, null: false, foreign_key: true
+      t.references :child, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_23_011449) do
+ActiveRecord::Schema[7.1].define(version: 2025_12_24_071536) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -62,6 +62,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_23_011449) do
     t.index ["user_id"], name: "index_diaries_on_user_id"
   end
 
+  create_table "diary_children", force: :cascade do |t|
+    t.bigint "diary_id", null: false
+    t.bigint "child_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["child_id"], name: "index_diary_children_on_child_id"
+    t.index ["diary_id"], name: "index_diary_children_on_diary_id"
+  end
+
   create_table "emojis", force: :cascade do |t|
     t.string "character"
     t.datetime "created_at", null: false
@@ -94,6 +103,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_23_011449) do
   add_foreign_key "children", "families"
   add_foreign_key "diaries", "emojis"
   add_foreign_key "diaries", "users"
+  add_foreign_key "diary_children", "children"
+  add_foreign_key "diary_children", "diaries"
   add_foreign_key "families", "users", column: "owner_id"
   add_foreign_key "users", "families"
 end

--- a/test/fixtures/diary_children.yml
+++ b/test/fixtures/diary_children.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  diary: one
+  child: one
+
+two:
+  diary: two
+  child: two

--- a/test/models/diary_child_test.rb
+++ b/test/models/diary_child_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DiaryChildTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
`DiaryChild`モデルと`diary_children`テーブルを作成

## 関連issue
#96 

## やったこと
 - `DiaryChild`モデルと`diary_children`テーブルを作成
 - アソシエーションを追加
	 - `app/models/diary.rb`
	 - `app/models/child.rb`
	 - `app/models/diary_child`

## やらないこと
 - 日記と子どもの情報を結びつけるロジックの実装

## テスト／完了確認
 - [x] テーブルが定義した通りに作成されたことを確認