### PR TITLE
Feature/#97 日記に子どもの情報を紐づける

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -18,6 +18,9 @@ class DiariesController < ApplicationController
   end
 
   def create
+    if params[:diary][:child_ids].is_a?(String)
+      params[:diary][:child_ids] = params[:diary][:child_ids].split(',')
+    end
     @diary = Diary.new(diary_params)
     @diary.user_id = current_user.id
     if @diary.save
@@ -37,6 +40,9 @@ class DiariesController < ApplicationController
   end
 
   def update
+    if params[:diary][:child_ids].is_a?(String)
+      params[:diary][:child_ids] = params[:diary][:child_ids].split(',')
+    end
     if @diary.update(diary_params)
       redirect_to diary_path(@diary.id), notice: '日記を更新しました。', status: :see_other
     else
@@ -60,7 +66,7 @@ class DiariesController < ApplicationController
   private
 
   def diary_params
-    params.require(:diary).permit(:date, :emoji_id, :body)
+    params.require(:diary).permit(:date, :emoji_id, :body, child_ids: [])
   end
 
   def set_diary

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -18,10 +18,8 @@ class DiariesController < ApplicationController
   end
 
   def create
-    if params[:diary][:child_ids].is_a?(String)
-      params[:diary][:child_ids] = params[:diary][:child_ids].split(',')
-    end
     @diary = Diary.new(diary_params)
+    process_child_ids
     @diary.user_id = current_user.id
     if @diary.save
       redirect_to diaries_path, notice: '日記を投稿しました。', status: :see_other
@@ -40,9 +38,7 @@ class DiariesController < ApplicationController
   end
 
   def update
-    if params[:diary][:child_ids].is_a?(String)
-      params[:diary][:child_ids] = params[:diary][:child_ids].split(',')
-    end
+    process_child_ids
     if @diary.update(diary_params)
       redirect_to diary_path(@diary.id), notice: '日記を更新しました。', status: :see_other
     else
@@ -67,6 +63,14 @@ class DiariesController < ApplicationController
 
   def diary_params
     params.require(:diary).permit(:date, :emoji_id, :body, child_ids: [])
+  end
+
+  def process_child_ids
+    # 文字列を数値の配列に変換してセットする
+    if params[:diary][:child_ids].is_a?(String)
+      params[:diary][:child_ids] = params[:diary][:child_ids].split(',')
+      @diary.child_ids = params[:diary][:child_ids]
+    end
   end
 
   def set_diary

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -9,12 +9,28 @@ function initializeReactApp() {
   const container = document.getElementById("root");
   
   if (container) {
-    // すでにrootが存在する場合は、新しく作らずにrenderだけ行う
+    // Reactが必要なページ
     if (!root) {
       root = createRoot(container);
     }
     root.render(<App />);
+  } else {
+    // Railsの通常のページ
+    // もし既存のReact rootがあるなら、メモリ解放のためにアンマウント
+    if (root) {
+      root.unmount();
+      root = null;
+    }
   }
 }
 
+// turbo:load はページ遷移のたびに走る
 document.addEventListener('turbo:load', initializeReactApp);
+
+// ページを離れる前にReactをクリーンアップ
+document.addEventListener('turbo:before-render', () => {
+  if (root) {
+    root.unmount();
+    root = null;
+  }
+});

--- a/app/javascript/react/pages/AuthPage.tsx
+++ b/app/javascript/react/pages/AuthPage.tsx
@@ -129,7 +129,7 @@ const useAuthLogic = () => {
       console.error('Auth Success 処理中にエラー:', error);
       return false;
     }
-  }, []);
+  }, [setFlashMessage, setUserProfile, setRailsSynced]);
 
 
   useEffect(() => {
@@ -220,7 +220,8 @@ const AuthPage: React.FC = () => {
     loading,
     handleSignOut,
     handleAuthSuccess,
-    flashMessage
+    flashMessage,
+    setIsProcessingSignUp
   } = useAuthLogic();
   const [view, setView] = useState<'signIn' | 'signUp' | 'forgotPassword' | 'updatePassword'>('signIn');
 

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -6,4 +6,21 @@ class Diary < ApplicationRecord
   has_many :children, through: :diary_children
   
   validates :date, :body, presence: true
+
+  def self.child_combination_options(family)
+    return [] unless family
+    
+    children = family.children.order(:id)
+    options = []
+
+    # 全ての子どもの組み合わせを生成
+    (1..children.size).each do |n|
+      children.to_a.combination(n).each do |combo|
+        label = combo.map(&:name).join("＆")
+        value = combo.map(&:id)
+        options << [label, value.join(",")]
+      end
+    end
+    options
+  end
 end

--- a/app/views/diaries/date_index.html.erb
+++ b/app/views/diaries/date_index.html.erb
@@ -7,7 +7,7 @@
         <div class="flex flex-col m-4 border rounded-md">
           <%# 1段目：絵文字（左寄せ） %>
           <div class="flex justify-start p-4">
-            <%= diary.emoji.character %>
+            <%= link_to diary.emoji.character, diary_path(diary.id), data: { turbo: false } %>
           </div>
 
           <%# 2段目：カテゴリ、タグ %>

--- a/app/views/diaries/date_index.html.erb
+++ b/app/views/diaries/date_index.html.erb
@@ -12,7 +12,9 @@
 
           <%# 2段目：カテゴリ、タグ %>
           <div class="flex justify-start gap-2 px-6">
-            <div class="border p-2">カテゴリ</div>
+            <% diary.children.map(&:name).each do |child| %>
+              <div class="border p-2"><%= child %></div>
+            <% end %>
             <div class="border p-2">タグ</div>
           </div>
 

--- a/app/views/diaries/edit.html.erb
+++ b/app/views/diaries/edit.html.erb
@@ -2,7 +2,7 @@
   <h1 class="text-3xl font-bold m-6">日記を編集</h1>
 
   <div id="diary_edit_form">
-    <%= form_with model: @diary, url: diary_path(diary_id: @diary.id), local: true do |f| %>
+    <%= form_with(model: @diary, url: diary_path(diary_id: @diary.id), data: { turbo: false }, local: true) do |f| %>
     <div class="my-4">
       <div>
         <%= f.label :date, "日付", class: "font-bold" %>

--- a/app/views/diaries/edit.html.erb
+++ b/app/views/diaries/edit.html.erb
@@ -13,10 +13,13 @@
     </div>
     <div class="my-4">
       <div>
-        <%= f.label :child_id, "どの子？", class: "font-bold" %>
+        <%= f.label :child_ids, "どの子？", class: "font-bold" %>
       </div>
       <div>
-        <!-- %= f.select :child_id, options_from_collection_for_select(@children, :id, :name, { :selected => @child.id }), include_blank: "選択してください", class: "border border-default-medium rounded-base" % -->
+        <%= f.select :child_ids, Diary.child_combination_options(current_user.family),
+              include_blank: "選択してください",
+              name: "diary[child_ids][]",
+              class: "border border-default-medium rounded-base" %>
       </div>
     </div>
     <div class="my-4">

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -8,7 +8,7 @@
 
         <% diary.each do |d| %>
           <div>
-            <%= link_to d.emoji.character, diary_path(d.id) %>
+            <%= link_to d.emoji.character, diary_path(d.id), data: { turbo: false } %>
           </div>
         <% end %>
       <% end %>

--- a/app/views/diaries/new.html.erb
+++ b/app/views/diaries/new.html.erb
@@ -13,10 +13,13 @@
     </div>
     <div class="my-4">
       <div>
-        <%= f.label :child_id, "どの子？", class: "font-bold" %>
+        <%= f.label :child_ids, "どの子？", class: "font-bold" %>
       </div>
       <div>
-        <!-- %= f.select :child_id, options_from_collection_for_select(@children, :id, :name), include_blank: "選択してください", class: "border border-default-medium rounded-base" % -->
+        <%= f.select :child_ids, Diary.child_combination_options(current_user.family),
+              include_blank: "選択してください",
+              name: "diary[child_ids][]",
+              class: "border border-default-medium rounded-base" %>
       </div>
     </div>
     <div class="my-4">

--- a/app/views/diaries/new.html.erb
+++ b/app/views/diaries/new.html.erb
@@ -2,7 +2,7 @@
   <h1 class="text-3xl font-bold m-6">日記を新規投稿</h1>
 
   <div id="diary_form">
-    <%= form_with model: @diary, url: diaries_path, method: :post, local: true do |f| %>
+    <%= form_with(model: @diary, method: :post, data: { turbo: false }, local: true) do |f| %>
     <div class="my-4">
       <div>
         <%= f.label :date, "日付", class: "font-bold" %>

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -21,6 +21,10 @@
           <td class="border-collapse border p-2"><%= @diary.user.name %></td>
         </tr>
         <tr>
+          <th class="border-collapse border p-2">children</th>
+          <td class="border-collapse border p-2"><%= @diary.children.map(&:name).join("＆") %></td>
+        </tr>
+        <tr>
           <th class="border-collapse border p-2">emoji's id</th>
           <td class="border-collapse border p-2"><%= @diary.emoji.id %></td>
         </tr>

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -22,7 +22,11 @@
         </tr>
         <tr>
           <th class="border-collapse border p-2">children</th>
-          <td class="border-collapse border p-2"><%= @diary.children.map(&:name).join("＆") %></td>
+          <td class="border-collapse border p-2">
+            <% @diary.children.map(&:name).each do |child| %>
+              <%= child %><br/>
+            <% end %>
+          </td>
         </tr>
         <tr>
           <th class="border-collapse border p-2">emoji's id</th>

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -41,7 +41,7 @@
           <td colspan="2">
             <div class="flex p-2">
               <div class="flex-auto">
-                <%= button_to "編集", edit_diary_path(diary_id: @diary.id), method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
+                <%= button_to "編集", edit_diary_path(diary_id: @diary.id), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
               </div>
               <div class="flex-auto">
                 <%= button_to "削除", diary_path(@diary.id), method: :delete, data: { turbo_method: :delete, turbo_confirm: '本当にこの日記を削除しますか？' }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>

--- a/app/views/families/children/edit.html.erb
+++ b/app/views/families/children/edit.html.erb
@@ -17,12 +17,12 @@
       </div>
 
       <div>
-        <%= f.submit "更新する", class: "box-border border border-default-medium shadow-xs font-medium rounded-full text-sm px-4 py-2 m-2" %>
+        <%= f.submit "更新する", data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium rounded-full text-sm px-4 py-2 m-2" %>
       </div>
     <% end %>
   </div>
 
   <div>
-    <%= link_to "キャンセル", family_path(@family) %>
+    <%= link_to "キャンセル", family_path(@family), data: { turbo: false } %>
   </div>
 </div>

--- a/app/views/families/children/edit.html.erb
+++ b/app/views/families/children/edit.html.erb
@@ -1,7 +1,7 @@
 <div id="edit_child" class="text-center">
   <h1 class="text-3xl font-bold m-6">子供の情報を編集</h1>
   <div class="my-10">
-    <%= form_with(model: [@family, @child]) do |f| %>
+    <%= form_with(model: [@family, @child], data: { turbo: false }) do |f| %>
       <div>
         <%= f.label :name, "名前" %>
       </div>

--- a/app/views/families/children/index.html.erb
+++ b/app/views/families/children/index.html.erb
@@ -11,7 +11,7 @@
         </td>
         <td>
           <% if @family.owner_id == current_user.id %>
-            <%= button_to "編集", edit_family_child_path(@family, child), method: :get, class: "box-border border border-default-medium shadow-xs font-medium rounded-full text-sm px-4 py-2 m-2" %>
+            <%= button_to "編集", edit_family_child_path(@family, child), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium rounded-full text-sm px-4 py-2 m-2" %>
         </td>
         <td>
             <%= button_to "削除",
@@ -27,6 +27,6 @@
   </div>
 
   <div>
-    <%= link_to "戻る", family_path(@family) %>
+    <%= link_to "戻る", family_path(@family), data: { turbo: false } %>
   </div>
 </div>

--- a/app/views/families/children/new.html.erb
+++ b/app/views/families/children/new.html.erb
@@ -1,7 +1,7 @@
 <div id="new_child" class="text-center">
   <h1 class="text-3xl font-bold m-6">子供の新規登録</h1>
   <div class="my-10">
-    <%= form_with(model: [@family, @child]) do |f| %>
+    <%= form_with(model: [@family, @child], data: { turbo: false }) do |f| %>
       <div>
         <%= f.label :name, "名前" %>
       </div>

--- a/app/views/families/children/new.html.erb
+++ b/app/views/families/children/new.html.erb
@@ -17,12 +17,12 @@
       </div>
 
       <div>
-        <%= f.submit "登録する", class: "box-border border border-default-medium shadow-xs font-medium rounded-full text-sm px-4 py-2 m-2" %>
+        <%= f.submit "登録する", data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium rounded-full text-sm px-4 py-2 m-2" %>
       </div>
     <% end %>
   </div>
 
   <div>
-    <%= link_to "戻る", family_path(@family) %>
+    <%= link_to "戻る", family_path(@family), data: { turbo: false } %>
   </div>
 </div>

--- a/app/views/families/families/edit.html.erb
+++ b/app/views/families/families/edit.html.erb
@@ -1,7 +1,7 @@
 <div id="edit_family" class="text-center">
   <h1 class="text-3xl font-bold m-6">家族（グループ）の編集</h1>
   <div id="family_form">
-    <%= form_with model: @family, url: family_path(id: @family.id), local: true do |f| %>
+    <%= form_with model: @family, url: family_path(id: @family.id), data: { turbo: false }, local: true do |f| %>
       <div>
         <div>
           <%= f.label :name, "家族（グループ）名", class: "font-bold" %>

--- a/app/views/families/families/edit.html.erb
+++ b/app/views/families/families/edit.html.erb
@@ -8,7 +8,7 @@
         </div>
         <div>
           <%= f.text_field :name, class: "border border-default-medium rounded-base" %>
-          <%= f.submit "更新", class: "box-border border border-default m-2 pl-2 pr-2" %>
+          <%= f.submit "更新", data: { turbo: false }, class: "box-border border border-default m-2 pl-2 pr-2" %>
         </div>
       </div>
     <% end %>
@@ -43,17 +43,17 @@
     </div>
     <% if @family.children.count > 0 && current_user.id == @family.owner_id %>
       <div>
-        <%= button_to "子どもの情報を編集・削除", family_children_path(family_id: @family.id), method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
+        <%= button_to "子どもの情報を編集・削除", family_children_path(family_id: @family.id), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
         <%= button_to "子どもの情報を追加", new_family_child_path(family_id: @family.id), method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
       </div>
     <% elsif current_user.id == @family.owner_id %>
       <div>
-        <%= button_to "子どもの情報を追加", new_family_child_path(family_id: @family.id), method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
+        <%= button_to "子どもの情報を追加", new_family_child_path(family_id: @family.id), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
       </div>
     <% end %>
   </div>
 
   <div class="mt-8">
-    <%= link_to "戻る", family_path(@family) %>
+    <%= link_to "戻る", family_path(@family), data: { turbo: false } %>
   </div>
 </div>

--- a/app/views/families/families/new.html.erb
+++ b/app/views/families/families/new.html.erb
@@ -8,7 +8,7 @@
   </div>
 
   <div id="family_code_form" class="my-10">
-    <%= form_with url: root_path, local: true do |f| %>
+    <%= form_with url: root_path, data: { turbo: false }, local: true do |f| %>
       <div>
         <%= f.label :code, '家族コードを入力' %>
       </div>
@@ -22,7 +22,7 @@
   </div>
 
   <div id="create_family_form" class="my-10">
-    <%= form_with(model: @family, url: families_path, local: true) do |f| %>
+    <%= form_with(model: @family, url: families_path, data: { turbo: false }, local: true) do |f| %>
       <div>
         <%= f.label :name, "家族（グループ）名" %>
       </div>

--- a/app/views/families/families/new.html.erb
+++ b/app/views/families/families/new.html.erb
@@ -30,7 +30,7 @@
         <%= f.text_field :name, class: "border border-default-medium rounded-base" %>
       </div>
       <div>
-        <%= f.submit "家族（グループ）を作成", class: "box-border border border-default-medium shadow-xs font-medium rounded-full text-sm px-4 py-2 m-2" %>
+        <%= f.submit "家族（グループ）を作成", data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium rounded-full text-sm px-4 py-2 m-2" %>
       </div>
     <% end %>
   </div>

--- a/app/views/families/families/show.html.erb
+++ b/app/views/families/families/show.html.erb
@@ -7,7 +7,7 @@
     </div>
     <% if current_user.id == @family.owner_id %>
       <div class="my-2">
-        <%= button_to '家族（グループ）名を編集する', edit_family_path, method: :get, class: "box-border border border-default-medium shadow-xs font-medium rounded-full text-sm px-4 py-2 m-2" %>
+        <%= button_to '家族（グループ）名を編集する', edit_family_path, method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium rounded-full text-sm px-4 py-2 m-2" %>
       </div>
     <% end %>
 
@@ -27,16 +27,16 @@
     </div>
     <% if @members.count > 1 && current_user.id == @family.owner_id %>
       <div>
-        <%= button_to "メンバーを削除", family_members_path(family_id: @family.id), method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
-        <%= button_to "メンバーを追加", new_family_member_path(family_id: @family.id), method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
+        <%= button_to "メンバーを削除", family_members_path(family_id: @family.id), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
+        <%= button_to "メンバーを追加", new_family_member_path(family_id: @family.id), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
       </div>
     <% elsif @members.count <= 1 && current_user.id == @family.owner_id %>
       <div>
-        <%= button_to "メンバーを追加", new_family_member_path(family_id: @family.id), method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
+        <%= button_to "メンバーを追加", new_family_member_path(family_id: @family.id), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
       </div>
     <% else %>
       <div>
-        <%= button_to "家族から脱退", family_members_path(family_id: @family.id), method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
+        <%= button_to "家族から脱退", family_members_path(family_id: @family.id), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
       </div>
     <% end %>
 
@@ -54,17 +54,17 @@
     </div>
     <% if @family.children.count > 0 && current_user.id == @family.owner_id %>
       <div class="my-2">
-        <%= button_to "子どもの情報を編集・削除", family_children_path(family_id: @family.id), method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
+        <%= button_to "子どもの情報を編集・削除", family_children_path(family_id: @family.id), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
         <%= button_to "子どもの情報を追加", new_family_child_path(family_id: @family.id), method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
       </div>
     <% elsif current_user.id == @family.owner_id %>
       <div class="my-2">
-        <%= button_to "子どもの情報を追加", new_family_child_path(family_id: @family.id), method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
+        <%= button_to "子どもの情報を追加", new_family_child_path(family_id: @family.id), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
       </div>
     <% end %>
 
     <div class="mt-8">
-      <%= link_to 'マイページへ', mypage_path %>
+      <%= link_to 'マイページへ', mypage_path, data: { turbo: false } %>
     </div>
 
   </div>

--- a/app/views/families/members/index.html.erb
+++ b/app/views/families/members/index.html.erb
@@ -24,6 +24,6 @@
   </div>
 
   <div class="mt-8">
-    <%= link_to "戻る", family_path(@family) %>
+    <%= link_to "戻る", family_path(@family), data: { turbo: false } %>
   </div>
 </div>

--- a/app/views/families/members/new.html.erb
+++ b/app/views/families/members/new.html.erb
@@ -1,7 +1,7 @@
 <div id="new_member" class="text-center">
   <h1 class="text-3xl font-bold m-6">家族（グループ）にメンバー追加</h1>
   <div class="my-10">
-    <%= form_with url: family_members_path(@family), method: :post do |f| %>
+    <%= form_with url: family_members_path(@family), method: :post, data: { turbo: false } do |f| %>
       <div>
         <%= f.label :email, "追加するユーザーのメールアドレス" %>
       </div>

--- a/app/views/families/members/new.html.erb
+++ b/app/views/families/members/new.html.erb
@@ -8,11 +8,11 @@
       <div>
         <%= f.email_field :email, class: "border border-default-medium rounded-base" %>
       </div>
-      <%= f.submit "追加する", class: "box-border border border-default-medium shadow-xs font-medium rounded-full text-sm px-4 py-2 m-2" %>
+      <%= f.submit "追加する", data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium rounded-full text-sm px-4 py-2 m-2" %>
     <% end %>
   </div>
 
   <div class="mt-8">
-    <%= link_to "戻る", family_path(@family) %>
+    <%= link_to "戻る", family_path(@family), data: { turbo: false } %>
   </div>
 </div>

--- a/app/views/layouts/_menu.html.erb
+++ b/app/views/layouts/_menu.html.erb
@@ -1,14 +1,14 @@
 <div class="grid grid-cols-4 gap-4 items-center p-6 bg-amber-100">
   <div id="new_article" class="text-center">
-    <%= link_to '日記を投稿', new_diary_path %>
+    <%= link_to '日記を投稿', new_diary_path, data: { turbo: false } %>
   </div>
   <div id="go_to_home" class="text-center">
-    <%= link_to 'ホーム', diaries_path %>
+    <%= link_to 'ホーム', diaries_path, data: { turbo: false } %>
   </div>
   <div id="search" class="text-center">
-    <%= link_to '検索', root_path %>
+    <%= link_to '検索', root_path, data: { turbo: false } %>
   </div>
   <div id="my_page" class="text-center">
-    <%= link_to 'マイページ', mypage_path %>
+    <%= link_to 'マイページ', mypage_path, data: { turbo: false } %>
   </div>
 </div>

--- a/app/views/mypages/edit.html.erb
+++ b/app/views/mypages/edit.html.erb
@@ -2,7 +2,7 @@
   <h1 class="text-3xl font-bold m-6">プロフィール編集</h1>
 
   <div id="user_form">
-    <%= form_with model: @user, url: mypage_path, method: :patch, local: true do |f| %>
+    <%= form_with model: @user, url: mypage_path, method: :patch, data: { turbo: false }, local: true do |f| %>
     <div class="my-4">
       <div class="justify-self-center">
         <%= image_tag @user.display_avatar, class: "w-24 h-24 rounded-full object-cover" %>
@@ -31,12 +31,12 @@
       </div>
     </div>
     <div class="my-4">
-      <%= f.submit "更新する", class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2.5" %>
+      <%= f.submit "更新する", data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2.5" %>
     </div>
     <% end %>
   </div>
 
   <div class="mt-8">
-    <%= link_to "戻る", mypage_path %>
+    <%= link_to "戻る", mypage_path, data: { turbo: false } %>
   </div>
 </div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -47,13 +47,13 @@
 
     <div class="mt-8 grid grid-cols-2 gap-4 place-items-center">
       <div id="user_edit_button" class="">
-        <%= button_to "ユーザー情報を確認", edit_mypage_path, method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2.5" %>
+        <%= button_to "ユーザー情報を確認", edit_mypage_path, method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2.5" %>
       </div>
       <div id="group_button">
         <% if current_user.family.present? %>
-          <%= button_to "家族（グループ）を確認", family_path(current_user.family.id), method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2.5" %>
+          <%= button_to "家族（グループ）を確認", family_path(current_user.family.id), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2.5" %>
         <% else %>
-          <%= button_to "家族（グループ）に入る・確認", new_family_path, method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2.5" %>
+          <%= button_to "家族（グループ）に入る・確認", new_family_path, method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2.5" %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
## 概要
日記に子どもの情報を紐づけ、表示する

## 関連issue
#97 

## やったこと
 - 新規投稿画面から日記に子どもの情報を紐づけて投稿できるようにした
 - 日記に紐づける子どもの情報を編集できるようにした
 - 日記の詳細表示画面で子どもの情報（子供の名前＝カテゴリ名）を表示するようにした
 - 1日ごとの日記一覧表示画面で子どもの情報（子供の名前＝カテゴリ名）を表示するようにした

## やらないこと
 - 子どもの情報で日記を絞り込む機能を実装する

## テスト／完了確認
 - [x] 日記（記録）の新規投稿画面から「子ども」が一人～複数人選択できることを確認する
 - [x] 日記（記録）の編集画面で「子ども」が一人～複数に選択できることを確認する
 - [x] 子どもの情報を紐づけて日記（記録）が投稿・編集できることを確認する
 - [x] 日記（記録）の詳細表示画面に子ども別のカテゴリが表示されることを確認する
 - [x] 日記（記録）の一覧表示画面に子ども別のカテゴリが表示されることを確認する

## 備考
ユーザー登録時、名前などの情報がRailsに渡らなくなっていたので`AuthPage.tsx`のロジックを修正した