### PR TITLE
Feature/#98 子ども別に日記をカテゴリ分けする機能

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -59,6 +59,23 @@ class DiariesController < ApplicationController
     @diaries =current_user.family.diaries.where(date: @date).order(created_at: :asc)
   end
 
+  def filter_by_child
+    # 1. 家族の日記をベースにする
+    @diaries = current_user.family.diaries.includes(:children, :emoji).order(date: :desc)
+
+    # 2. child_idで絞り込むロジック
+    if params[:child_ids].present?
+      @diaries = @diaries.joins(:diary_children)
+                        .where(diary_children: { child_id: params[:child_ids] })
+                        .distinct
+      
+      # 3. ビュー表示用に「現在選択されている子供たち」を取得
+      @selected_children = current_user.family.children.where(id: params[:child_ids])
+    else
+      @diaries = []
+    end
+  end
+
   private
 
   def diary_params

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -1,0 +1,29 @@
+<div id="diary" class="w-2/3 justify-self-center">
+  <div class="flex flex-col m-4 border rounded-md">
+    <%# 1段目：絵文字（左寄せ） %>
+    <div class="flex justify-start p-4">
+      <%= link_to diary.emoji.character, diary_path(diary.id), data: { turbo: false } %>
+    </div>
+
+    <%# 2段目：カテゴリ、タグ %>
+    <div class="flex justify-start gap-2 px-6">
+      <% diary.children.each do |child| %>
+        <div class="border p-2"><%= link_to child.name, filter_by_child_diaries_path("child_ids[]" => child.id), data: { turbo: false }, class: "child-link" %></div>
+      <% end %>
+      <div class="border p-2">タグ</div>
+    </div>
+
+    <%# 3段目：ID、家族ID、家族名、ユーザー名 %>
+    <div class="flex justify-center m-2">
+      <div class="p-2">id：<%= diary.id %></div>
+      <div class="p-2">family_id：<%= diary.user.family_id %></div>
+      <div class="p-2">family name：<%= diary.user.family.name %></div>
+      <div class="p-2">user：<%= diary.user.name %></div>
+    </div>
+
+    <%# 4段目：本文 %>
+    <div class="flex justify-start m-2 px-4 py-2">
+      <%= diary.body %>
+    </div>
+  </div>
+</div>

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -8,7 +8,20 @@
     <%# 2段目：カテゴリ、タグ %>
     <div class="flex justify-start gap-2 px-6">
       <% diary.children.each do |child| %>
-        <div class="border p-2"><%= link_to child.name, filter_by_child_diaries_path("child_ids[]" => child.id), data: { turbo: false }, class: "child-link" %></div>
+        <%
+          current_ids = Array.wrap(params[:child_ids]).map(&:to_s)
+          
+          if current_ids.include?(child.id.to_s)
+            # すでに選択済みなら、そのIDを取り除く（解除リンクになる）
+            next_ids = current_ids - [child.id.to_s]
+          else
+            # 未選択なら、IDを追加する
+            next_ids = current_ids + [child.id.to_s]
+          end
+        %>
+        <div class="border p-2">
+          <%= link_to child.name, filter_by_child_diaries_path(child_ids: next_ids), data: { turbo: false } %>
+        </div>
       <% end %>
       <div class="border p-2">タグ</div>
     </div>

--- a/app/views/diaries/date_index.html.erb
+++ b/app/views/diaries/date_index.html.erb
@@ -2,37 +2,7 @@
   <h1 class="text-3xl font-bold m-6"><%= l(@date.to_date, format: :long) %>の日記</h1>
 
   <% if @diaries.any? %>
-    <div id="diary" class="w-2/3 justify-self-center">
-      <% @diaries.each do |diary| %>
-        <div class="flex flex-col m-4 border rounded-md">
-          <%# 1段目：絵文字（左寄せ） %>
-          <div class="flex justify-start p-4">
-            <%= link_to diary.emoji.character, diary_path(diary.id), data: { turbo: false } %>
-          </div>
-
-          <%# 2段目：カテゴリ、タグ %>
-          <div class="flex justify-start gap-2 px-6">
-            <% diary.children.map(&:name).each do |child| %>
-              <div class="border p-2"><%= child %></div>
-            <% end %>
-            <div class="border p-2">タグ</div>
-          </div>
-
-          <%# 3段目：ID、家族ID、家族名、ユーザー名 %>
-          <div class="flex justify-center m-2">
-            <div class="p-2">id：<%= diary.id %></div>
-            <div class="p-2">family_id：<%= diary.user.family_id %></div>
-            <div class="p-2">family name：<%= diary.user.family.name %></div>
-            <div class="p-2">user：<%= diary.user.name %></div>
-          </div>
-
-          <%# 4段目：本文 %>
-          <div class="flex justify-start m-2 px-4 py-2">
-            <%= diary.body %>
-          </div>
-        </div>
-      <% end %>
-    </div>
+    <%= render @diaries %>
   <% else %>
     <div>
       <p>日記はありません。</p>
@@ -40,6 +10,6 @@
   <% end %>
 
   <div class="my-8">
-    <%= link_to "カレンダーに戻る", diaries_path %>
+    <%= link_to "カレンダーに戻る", diaries_path, data: { turbo: false } %>
   </div>
 </div>

--- a/app/views/diaries/filter_by_child.html.erb
+++ b/app/views/diaries/filter_by_child.html.erb
@@ -1,13 +1,19 @@
 <div id="filter_by_child" class="text-center">
-  <h1 class="text-3xl font-bold m-6">日記を絞り込む：
-    <% if @selected_children.present? %>
-      <% @selected_children.each do |child| %>
+  <h1 class="text-3xl font-bold mt-6">日記を絞り込む</h1>
+
+  <% if @selected_children.present? %>
+    <div class="flex justify-center gap-2">
+    <% @selected_children.each do |child| %>
+      <div class="border p-2 my-6">
         <%= child.name %>
-      <% end %>
-    <% else %>
-      対象なし
+      </div>
     <% end %>
-  </h1>
+    </div>
+  <% else %>
+    <div class="flex justify-center p-2 my-6">
+      対象なし
+    </div>
+  <% end %>
 
   <% if @selected_children.present? %>
     <div class="search-status">

--- a/app/views/diaries/filter_by_child.html.erb
+++ b/app/views/diaries/filter_by_child.html.erb
@@ -1,0 +1,26 @@
+<div id="filter_by_child" class="text-center">
+  <h1 class="text-3xl font-bold m-6">日記を絞り込む：
+    <% if @selected_children.present? %>
+      <% @selected_children.each do |child| %>
+        <%= child.name %>
+      <% end %>
+    <% else %>
+      対象なし
+    <% end %>
+  </h1>
+
+  <% if @selected_children.present? %>
+    <div class="search-status">
+      <%= button_to "絞り込みを解除", filter_by_child_diaries_path, method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2.5" %>
+    </div>
+  <% end %>
+
+  <div class="diary-list">
+    <% if @diaries.any? %>
+      <%= render @diaries %>
+    <% else %>
+      <p>該当する日記はありません。</p>
+    <% end %>
+  </div>
+
+</div>

--- a/app/views/diaries/filter_by_child.html.erb
+++ b/app/views/diaries/filter_by_child.html.erb
@@ -5,7 +5,18 @@
     <div class="flex justify-center gap-2">
     <% @selected_children.each do |child| %>
       <div class="border p-2 my-6">
-        <%= child.name %>
+        <%
+          current_ids = Array.wrap(params[:child_ids]).map(&:to_s)
+          
+          if current_ids.include?(child.id.to_s)
+            # すでに選択済みなら、そのIDを取り除く（解除リンクになる）
+            next_ids = current_ids - [child.id.to_s]
+          else
+            # 未選択なら、IDを追加する
+            next_ids = current_ids + [child.id.to_s]
+          end
+        %>
+        <%= link_to child.name, filter_by_child_diaries_path(child_ids: next_ids), data: { turbo: false } %>
       </div>
     <% end %>
     </div>
@@ -17,7 +28,7 @@
 
   <% if @selected_children.present? %>
     <div class="search-status">
-      <%= button_to "絞り込みを解除", filter_by_child_diaries_path, method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2.5" %>
+      <%= button_to "すべての絞り込みを解除", filter_by_child_diaries_path, method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2.5" %>
     </div>
   <% end %>
 

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -23,8 +23,8 @@
         <tr>
           <th class="border-collapse border p-2">children</th>
           <td class="border-collapse border p-2">
-            <% @diary.children.map(&:name).each do |child| %>
-              <%= child %><br/>
+            <% @diary.children.each do |child| %>
+              <%= link_to child.name, filter_by_child_diaries_path("child_ids[]" => child.id), data: { turbo: false }, class: "child-link" %><br/>
             <% end %>
           </td>
         </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   resources :diaries do
     collection do
       get 'date_index'
+      get 'filter_by_child'
     end
   end
     


### PR DESCRIPTION
## 概要
子ども別にカテゴリ分けをし、子どもを指定して日記を絞り込む機能を実装

## 関連issue
#98 

## やったこと
 - 子どもを指定して日記を絞り込む機能を実装
	 - 子どもの名前を選択するとその子で絞り込んで日記一覧を表示する
	 - 絞り込んだうえで子どもの名前を選択すると絞り込みを解除する
 - 日記一覧を表示する部分をパーシャル化

## やらないこと
 - UIを綺麗にする

## テスト／完了確認
 - [x] 子ども別に日記（記録）を表示する機能を実装する
 - [x] 子どもの名前に、その子だけの日記（記事）を表示するためのリンクを付与する
 - [x] 子どもの名前を選択すると、その子に関する日記（記事）のみが表示されることを確認する
 - [x] 子どもの名前を再び選択すると、絞り込みが解除されることを確認する