### PR TITLE
Feature/#99 Reactionモデルとreactionsテーブルを定義

### DIFF
--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -4,6 +4,7 @@ class Diary < ApplicationRecord
 
   has_many :diary_children, dependent: :destroy
   has_many :children, through: :diary_children
+  has_many :reactions, dependent: :destroy
   
   validates :date, :body, presence: true
 

--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -1,4 +1,6 @@
 class Emoji < ApplicationRecord
   has_many :diaries
+  has_many :reactions
+
   validates :character, presence: true, uniqueness: true
 end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -1,0 +1,5 @@
+class Reaction < ApplicationRecord
+  belongs_to :user
+  belongs_to :diary
+  belongs_to :emoji
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   has_one :owned_family, class_name: 'Family', foreign_key: 'owner_id'
   has_one_attached :avatar
   has_many :diaries, dependent: :destroy
+  has_many :reactions
 
   validates :supabase_uid, presence: true, uniqueness: true
   validates :email, presence: true, uniqueness: true

--- a/db/migrate/20251226004429_create_reactions.rb
+++ b/db/migrate/20251226004429_create_reactions.rb
@@ -1,0 +1,14 @@
+class CreateReactions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :reactions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :diary, null: false, foreign_key: true
+      t.references :emoji, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    # 同じ人が同じ日記に、同じ絵文字を何度も送れないようにする
+    add_index :reactions, [:user_id, :diary_id, :emoji_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_24_071536) do
+ActiveRecord::Schema[7.1].define(version: 2025_12_26_004429) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -86,6 +86,18 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_24_071536) do
     t.index ["owner_id"], name: "index_families_on_owner_id", unique: true
   end
 
+  create_table "reactions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "diary_id", null: false
+    t.bigint "emoji_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["diary_id"], name: "index_reactions_on_diary_id"
+    t.index ["emoji_id"], name: "index_reactions_on_emoji_id"
+    t.index ["user_id", "diary_id", "emoji_id"], name: "index_reactions_on_user_id_and_diary_id_and_emoji_id", unique: true
+    t.index ["user_id"], name: "index_reactions_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
     t.string "name"
@@ -106,5 +118,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_24_071536) do
   add_foreign_key "diary_children", "children"
   add_foreign_key "diary_children", "diaries"
   add_foreign_key "families", "users", column: "owner_id"
+  add_foreign_key "reactions", "diaries"
+  add_foreign_key "reactions", "emojis"
+  add_foreign_key "reactions", "users"
   add_foreign_key "users", "families"
 end

--- a/test/fixtures/reactions.yml
+++ b/test/fixtures/reactions.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  diary: one
+  emoji: one
+
+two:
+  user: two
+  diary: two
+  emoji: two

--- a/test/models/reaction_test.rb
+++ b/test/models/reaction_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReactionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
Reactionモデルとreactionsテーブルを追加する

## 関連issue
#99 

## やったこと
 - `Reaction`モデルと`reactions`テーブルを追加
 - `Reaction`とのアソシエーションを定義
	 - `Diary`
	 - `User`
	 - `Emoji`

## やらないこと
 - 日記にリアクションを付与する機能を実装する

## テスト／完了確認
 - [x] reactionsテーブルのカラムが定義した通りになっていることを確認

## 変更点
 - `diaries_reactions`テーブルは作成しない
 - `Reaction`でリアクションのための絵文字を定義せず、`emojis`テーブルの絵文字を利用する
	 - 「誰が」「どの絵文字を使って」「どの日記に」リアクションしたかを管理する構成にする