### PR TITLE
Feature/#101 絵文字で日記を絞り込む機能

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -59,7 +59,7 @@ class DiariesController < ApplicationController
     @diaries =current_user.family.diaries.where(date: @date).order(created_at: :asc)
   end
 
-  def filter_by_child
+  def filter
     # 1. 家族の日記をベースにする
     @diaries = current_user.family.diaries.includes(:children, :emoji).order(date: :desc)
 

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -6,7 +6,7 @@ class Diary < ApplicationRecord
   has_many :children, through: :diary_children
   has_many :reactions, dependent: :destroy
   
-  validates :date, :body, presence: true
+  validates :date, :body, :children, presence: true
 
   def self.child_combination_options(family)
     return [] unless family

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -1,14 +1,14 @@
-<div id="diary" class="w-2/3 justify-self-center cursor-pointer" onclick='window.location="<%= diary_path(diary.id) %>"' role="link" data-turbolinks="false">
+<div id="diary" class="w-2/3 justify-self-center relative transition">
   <div class="flex flex-col m-4 border rounded-md">
     <%# 1段目：絵文字（左寄せ） %>
     <div class="flex justify-start p-4 relative z-10">
-<%= link_to filter_diaries_path(child_ids: params[:child_ids], emoji_id: diary.emoji.id), data: { turbo: false } do %>
-      <%= diary.emoji.character %>
-<% end %>
+      <%= link_to filter_diaries_path(child_ids: params[:child_ids], emoji_id: diary.emoji.id), data: { turbo: false } do %>
+        <%= diary.emoji.character %>
+      <% end %>
     </div>
 
     <%# 2段目：カテゴリ、タグ %>
-    <div class="flex justify-start gap-2 px-6">
+    <div class="flex justify-start gap-2 px-6 relative z-10">
       <% diary.children.each do |child| %>
         <%
           current_ids = Array.wrap(params[:child_ids]).map(&:to_s)
@@ -25,20 +25,23 @@
           <%= link_to child.name, filter_diaries_path(child_ids: next_ids, emoji_id: params[:emoji_id]), data: { turbo: false } %>
         </div>
       <% end %>
-      <div class="border p-2 cursor-default">タグ</div>
+      <div class="border p-2 relative z-10">タグ</div>
     </div>
 
     <%# 3段目：ID、家族ID、家族名、ユーザー名 %>
     <div class="flex justify-center m-2">
-      <div class="p-2 cursor-default">id：<%= diary.id %></div>
-      <div class="p-2 cursor-default">family_id：<%= diary.user.family_id %></div>
-      <div class="p-2 cursor-default">family name：<%= diary.user.family.name %></div>
-      <div class="p-2 cursor-default">user：<%= diary.user.name %></div>
+      <div class="p-2">id：<%= diary.id %></div>
+      <div class="p-2">family_id：<%= diary.user.family_id %></div>
+      <div class="p-2">family name：<%= diary.user.family.name %></div>
+      <div class="p-2">user：<%= diary.user.name %></div>
     </div>
 
     <%# 4段目：本文 %>
-    <div class="flex justify-start m-2 px-4 py-2 cursor-default">
+    <div class="flex justify-start m-2 px-4 py-2">
       <%= diary.body %>
     </div>
   </div>
+  <%= link_to "", diary_path(diary),
+      class: "absolute inset-0 z-0",
+      data: { turbo: false } %>
 </div>

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -1,8 +1,10 @@
 <div id="diary" class="w-2/3 justify-self-center cursor-pointer" onclick='window.location="<%= diary_path(diary.id) %>"' role="link" data-turbolinks="false">
   <div class="flex flex-col m-4 border rounded-md">
     <%# 1段目：絵文字（左寄せ） %>
-    <div class="flex justify-start p-4">
+    <div class="flex justify-start p-4 relative z-10">
+<%= link_to filter_diaries_path(child_ids: params[:child_ids], emoji_id: diary.emoji.id), data: { turbo: false } do %>
       <%= diary.emoji.character %>
+<% end %>
     </div>
 
     <%# 2段目：カテゴリ、タグ %>
@@ -20,7 +22,7 @@
           end
         %>
         <div class="border p-2">
-          <%= link_to child.name, filter_diaries_path(child_ids: next_ids), data: { turbo: false } %>
+          <%= link_to child.name, filter_diaries_path(child_ids: next_ids, emoji_id: params[:emoji_id]), data: { turbo: false } %>
         </div>
       <% end %>
       <div class="border p-2 cursor-default">タグ</div>

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -1,8 +1,8 @@
-<div id="diary" class="w-2/3 justify-self-center">
+<div id="diary" class="w-2/3 justify-self-center cursor-pointer" onclick='window.location="<%= diary_path(diary.id) %>"' role="link" data-turbolinks="false">
   <div class="flex flex-col m-4 border rounded-md">
     <%# 1段目：絵文字（左寄せ） %>
     <div class="flex justify-start p-4">
-      <%= link_to diary.emoji.character, diary_path(diary.id), data: { turbo: false } %>
+      <%= diary.emoji.character %>
     </div>
 
     <%# 2段目：カテゴリ、タグ %>
@@ -23,19 +23,19 @@
           <%= link_to child.name, filter_by_child_diaries_path(child_ids: next_ids), data: { turbo: false } %>
         </div>
       <% end %>
-      <div class="border p-2">タグ</div>
+      <div class="border p-2 cursor-default">タグ</div>
     </div>
 
     <%# 3段目：ID、家族ID、家族名、ユーザー名 %>
     <div class="flex justify-center m-2">
-      <div class="p-2">id：<%= diary.id %></div>
-      <div class="p-2">family_id：<%= diary.user.family_id %></div>
-      <div class="p-2">family name：<%= diary.user.family.name %></div>
-      <div class="p-2">user：<%= diary.user.name %></div>
+      <div class="p-2 cursor-default">id：<%= diary.id %></div>
+      <div class="p-2 cursor-default">family_id：<%= diary.user.family_id %></div>
+      <div class="p-2 cursor-default">family name：<%= diary.user.family.name %></div>
+      <div class="p-2 cursor-default">user：<%= diary.user.name %></div>
     </div>
 
     <%# 4段目：本文 %>
-    <div class="flex justify-start m-2 px-4 py-2">
+    <div class="flex justify-start m-2 px-4 py-2 cursor-default">
       <%= diary.body %>
     </div>
   </div>

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -20,7 +20,7 @@
           end
         %>
         <div class="border p-2">
-          <%= link_to child.name, filter_by_child_diaries_path(child_ids: next_ids), data: { turbo: false } %>
+          <%= link_to child.name, filter_diaries_path(child_ids: next_ids), data: { turbo: false } %>
         </div>
       <% end %>
       <div class="border p-2 cursor-default">タグ</div>

--- a/app/views/diaries/edit.html.erb
+++ b/app/views/diaries/edit.html.erb
@@ -26,7 +26,10 @@
         <%= f.label :emoji_id, "絵文字", class: "font-bold" %>
       </div>
       <div>
-        <%= f.select :emoji_id, options_from_collection_for_select(@emojis, :id, :character, { :selected => @emoji.id }), include_blank: "選択してください", class: "border border-default-medium rounded-base" %>
+        <%= f.select :emoji_id,
+            options_from_collection_for_select(@emojis, :id, :character, f.object.emoji_id), 
+            { include_blank: "選択してください" },
+            { class: "border border-default-medium" } %>
       </div>
     </div>
     <div class="my-4">

--- a/app/views/diaries/edit.html.erb
+++ b/app/views/diaries/edit.html.erb
@@ -8,7 +8,7 @@
         <%= f.label :date, "日付", class: "font-bold" %>
       </div>
       <div>
-        <%= f.date_field :date, class: "border border-default-medium rounded-base" %>
+        <%= f.date_field :date, class: "border border-default-medium" %>
       </div>
     </div>
     <div class="my-4">
@@ -19,7 +19,7 @@
         <%= f.select :child_ids, Diary.child_combination_options(current_user.family),
               include_blank: "選択してください",
               name: "diary[child_ids][]",
-              class: "border border-default-medium rounded-base" %>
+              class: "border border-default-medium" %>
       </div>
     </div>
     <div class="my-4">
@@ -34,7 +34,7 @@
         <%= f.label :body, "本文", class: "font-bold" %>
       </div>
       <div>
-        <%= f.text_area :body, class: "border border-default-medium rounded-base" %>
+        <%= f.text_area :body, class: "border border-default-medium" %>
       </div>
     </div>
     <div class="my-4">

--- a/app/views/diaries/filter.html.erb
+++ b/app/views/diaries/filter.html.erb
@@ -1,4 +1,4 @@
-<div id="filter_by_child" class="text-center">
+<div id="filter_diaries" class="text-center">
   <h1 class="text-3xl font-bold mt-6">日記を絞り込む</h1>
 
   <% if @selected_children.present? %>
@@ -16,7 +16,7 @@
             next_ids = current_ids + [child.id.to_s]
           end
         %>
-        <%= link_to child.name, filter_by_child_diaries_path(child_ids: next_ids), data: { turbo: false } %>
+        <%= link_to child.name, filter_diaries_path(child_ids: next_ids), data: { turbo: false } %>
       </div>
     <% end %>
     </div>
@@ -28,7 +28,7 @@
 
   <% if @selected_children.present? %>
     <div class="search-status">
-      <%= button_to "すべての絞り込みを解除", filter_by_child_diaries_path, method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2.5" %>
+      <%= button_to "すべての絞り込みを解除", filter_diaries_path, method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2.5" %>
     </div>
   <% end %>
 

--- a/app/views/diaries/filter.html.erb
+++ b/app/views/diaries/filter.html.erb
@@ -1,36 +1,44 @@
 <div id="filter_diaries" class="text-center">
   <h1 class="text-3xl font-bold mt-6">日記を絞り込む</h1>
 
-  <% if @selected_children.present? %>
-    <div class="flex justify-center gap-2">
-    <% @selected_children.each do |child| %>
-      <div class="border p-2 my-6">
-        <%
-          current_ids = Array.wrap(params[:child_ids]).map(&:to_s)
-          
-          if current_ids.include?(child.id.to_s)
-            # すでに選択済みなら、そのIDを取り除く（解除リンクになる）
-            next_ids = current_ids - [child.id.to_s]
-          else
-            # 未選択なら、IDを追加する
-            next_ids = current_ids + [child.id.to_s]
-          end
-        %>
-        <%= link_to child.name, filter_diaries_path(child_ids: next_ids), data: { turbo: false } %>
-      </div>
-    <% end %>
-    </div>
-  <% else %>
-    <div class="flex justify-center p-2 my-6">
-      対象なし
-    </div>
-  <% end %>
+  <div class="flex flex-wrap justify-center gap-2 my-6">
+    <% if @selected_children.present? || @selected_emoji.present? %>
+      
+      <% if @selected_children.present? %>
+        <%# --- 子どものバッジ表示 --- %>
+        <% @selected_children.each do |child| %>
+          <div class="flex items-center border border-blue-500 bg-blue-50 px-3 py-1 rounded-full text-blue-700 shadow-sm">
+            <%
+              remaining_child_ids = Array.wrap(params[:child_ids]) - [child.id.to_s]
+            %>
+            <%= link_to filter_diaries_path(child_ids: remaining_child_ids, emoji_id: params[:emoji_id]),
+                        data: { turbo: false }, class: "flex items-center hover:opacity-70" do %>
+              <span class="mr-1">✕</span>
+              <span><%= child.name %></span>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+      
+      <%# --- 絵文字のバッジ表示 --- %>
+      <% if @selected_emoji.present? %>
+        <div class="flex items-center border border-yellow-500 bg-yellow-50 px-3 py-1 rounded-full text-lg shadow-sm">
+          <%# クリックで絵文字を解除（emoji_idをnilにするが、child_idsは維持） %>
+          <%= link_to filter_diaries_path(child_ids: params[:child_ids], emoji_id: nil), 
+                      data: { turbo: false }, class: "flex items-center hover:opacity-70" do %>
+            <span class="mr-2 text-sm text-yellow-700">✕</span>
+            <span><%= @selected_emoji.character %></span>
+          <% end %>
+        </div>
+      <% end %>
 
-  <% if @selected_children.present? %>
-    <div class="search-status">
-      <%= button_to "すべての絞り込みを解除", filter_diaries_path, method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2.5" %>
-    </div>
-  <% end %>
+      <%# --- すべてクリアボタン（あると親切） --- %>
+      <div class="ml-4 flex items-center">
+        <%= link_to "クリア", filter_diaries_path, class: "text-sm text-gray-500 underline hover:text-gray-700" %>
+      </div>
+
+    <% end %>
+  </div>
 
   <div class="diary-list">
     <% if @diaries.any? %>

--- a/app/views/diaries/new.html.erb
+++ b/app/views/diaries/new.html.erb
@@ -8,7 +8,7 @@
         <%= f.label :date, "日付", class: "font-bold" %>
       </div>
       <div>
-        <%= f.date_field :date, class: "border border-default-medium rounded-base" %>
+        <%= f.date_field :date, class: "border border-default-medium" %>
       </div>
     </div>
     <div class="my-4">
@@ -19,14 +19,14 @@
         <%= f.select :child_ids, Diary.child_combination_options(current_user.family),
               include_blank: "選択してください",
               name: "diary[child_ids][]",
-              class: "border border-default-medium rounded-base" %>
+              class: "border border-default-medium" %>
       </div>
     </div>
     <div class="my-4">
         <%= f.label :emoji_id, "絵文字", class: "font-bold" %>
       </div>
       <div>
-        <%= f.select :emoji_id, options_from_collection_for_select(@emojis, :id, :character), include_blank: "選択してください", class: "border border-default-medium rounded-base" %>
+        <%= f.select :emoji_id, options_from_collection_for_select(@emojis, :id, :character), include_blank: "選択してください", class: "border border-default-medium" %>
       </div>
     </div>
     <div class="my-4">
@@ -34,7 +34,7 @@
         <%= f.label :body, "本文", class: "font-bold" %>
       </div>
       <div>
-        <%= f.text_area :body, class: "border border-default-medium rounded-base" %>
+        <%= f.text_area :body, class: "border border-default-medium" %>
       </div>
     </div>
     <div class="my-4">

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -24,7 +24,7 @@
           <th class="border-collapse border p-2">children</th>
           <td class="border-collapse border p-2">
             <% @diary.children.each do |child| %>
-              <%= link_to child.name, filter_by_child_diaries_path("child_ids[]" => child.id), data: { turbo: false }, class: "child-link" %><br/>
+              <%= link_to child.name, filter_diaries_path("child_ids[]" => child.id), data: { turbo: false }, class: "child-link" %><br/>
             <% end %>
           </td>
         </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   resources :diaries do
     collection do
       get 'date_index'
-      get 'filter_by_child'
+      get 'filter'
     end
   end
     


### PR DESCRIPTION
## 概要
登録した絵文字で日記を絞り込む機能を実装

## 関連issue
#101 

## やったこと
 - `filter_by_child`アクションを`filter`アクションに変更
 - アクション名を変更したことに伴い、`filter_by_child.html.erb`を`filter.html.erb`に変更し、ルーティングの記述も変更
 - `filter`アクションで、絵文字と子ども両方で日記を絞り込む機能を実装
 - `Diary`モデルに「`child_id`を空にしてはならない」バリデーションを追加
 - 日記編集画面で`emoji_id`を選択するフィールドのコードを修正

## やらないこと
 - 日記一覧表示画面のUIを整える

## テスト／完了確認
 - [x] 絵文字を選択すると日記を絞り込んで表示できることを確認
 - [x] 絵文字と子どもの両方で日記を絞り込んで表示できることを確認