### PR TITLE
Feature/#102 日記にリアクションを追加・削除する機能

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -90,6 +90,12 @@ class DiariesController < ApplicationController
     end
   end
 
+  def refresh_emoji
+    @diary = Diary.find(params[:id])
+    # 独自のレイアウトを使わず、パーシャルだけを返す
+    render partial: 'diaries/emoji_list', locals: { diary: @diary }
+  end
+
   private
 
   def diary_params

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -4,7 +4,7 @@ class ReactionsController < ApplicationController
     
     # 1. 家族チェック（日記の家族IDと、自分の家族IDが一致するか）
     # 2. 自分自身ではないチェック（日記の投稿者と自分が一致しないか）
-    if @diary.family_id == current_user.family_id && @diary.user_id != current_user.id
+    if @diary.user.family_id == current_user.family_id && @diary.user_id != current_user.id
       @reaction = @diary.reactions.new(
         user: current_user,
         emoji_id: params[:emoji_id]

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -1,0 +1,27 @@
+class ReactionsController < ApplicationController
+  def create
+    @diary = Diary.find(params[:diary_id])
+    
+    # 1. 家族チェック（日記の家族IDと、自分の家族IDが一致するか）
+    # 2. 自分自身ではないチェック（日記の投稿者と自分が一致しないか）
+    if @diary.family_id == current_user.family_id && @diary.user_id != current_user.id
+      @reaction = @diary.reactions.new(
+        user: current_user,
+        emoji_id: params[:emoji_id]
+      )
+      if @reaction.save
+        redirect_back fallback_location: diaries_path, notice: "リアクションしました"
+      else
+        redirect_back fallback_location: diaries_path, alert: "リアクションに失敗しました"
+      end
+    else
+      redirect_back fallback_location: diaries_path, alert: "自分自身の日記にはリアクションできません"
+    end
+  end
+
+  def destroy
+    @reaction = current_user.reactions.find(params[:id])
+    @reaction.destroy
+    redirect_back fallback_location: diaries_path, notice: "リアクションを取り消しました"
+  end
+end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -2,4 +2,20 @@ class Reaction < ApplicationRecord
   belongs_to :user
   belongs_to :diary
   belongs_to :emoji
+
+  # 1人1つの絵文字につき1回まで
+  validates :user_id, uniqueness: { scope: [:diary_id, :emoji_id], message: "同じリアクションは既に登録済みです" }
+
+  # 1人1つの日記に絵文字は合計5つまで
+  validate :validate_reactions_count_limit, on: :create
+
+  private
+
+  def validate_reactions_count_limit
+    # 自分がこの日記に既に付けているリアクションの数をカウント
+    existing_count = user.reactions.where(diary_id: diary_id).count
+    if existing_count >= 5
+      errors.add(:base, "1つの日記に付けられるリアクションは5つまでです")
+    end
+  end
 end

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -40,6 +40,12 @@
     <div class="flex justify-start m-2 px-4 py-2">
       <%= diary.body %>
     </div>
+
+    <% if diary.user != current_user %>
+    <div class="flex justify-end m-2 px-4 py-2">
+      <%= render 'diaries/reaction', diary: diary %>
+    </div>
+    <% end %>
   </div>
   <%= link_to "", diary_path(diary),
       class: "absolute inset-0 z-0",

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -43,7 +43,7 @@
 
     <% if diary.user != current_user %>
     <div class="flex justify-end m-2 px-4 py-2">
-      <%= render 'diaries/reaction', diary: diary %>
+      <%= render 'reaction', diary: diary %>
     </div>
     <% end %>
   </div>

--- a/app/views/diaries/_emoji_list.html.erb
+++ b/app/views/diaries/_emoji_list.html.erb
@@ -1,0 +1,9 @@
+<%= turbo_frame_tag "emoji_palette_#{diary.id}" do %>
+  <div class="absolute bottom-full left-0 mb-2 flex bg-white border shadow-xl rounded-lg p-2 gap-2 z-50 min-w-max items-center">
+    <% Emoji.order("RANDOM()").limit(6).each do |emoji| %>
+      <%= button_to emoji.character, diary_reactions_path(diary, emoji_id: emoji.id),
+                    method: :post, data: { turbo_frame: "_top" } %>
+    <% end %>
+    <%= link_to "↻", refresh_emoji_diary_path(diary), class: "ml-2 text-gray-400 hover:text-blue-500 text-sm" %>
+  </div>
+<% end %>

--- a/app/views/diaries/_reaction.html.erb
+++ b/app/views/diaries/_reaction.html.erb
@@ -1,0 +1,55 @@
+<div class="flex flex-wrap gap-2 mt-4">
+  <div class="flex flex-wrap gap-2 mt-2">
+    <%# 日記に付いているリアクションを「絵文字ごと」にまとめてループ %>
+    <% diary.reactions.group(:emoji_id).count.each do |emoji_id, count| %>
+      <%
+        emoji = Emoji.find(emoji_id)
+        # 自分がこの日記の、この絵文字にリアクションしているか探す
+        my_reaction = diary.reactions.find_by(emoji_id: emoji_id, user_id: current_user.id)
+      %>
+
+      <% if my_reaction %>
+        <%# 自分のリアクションなら、DELETEメソッドで削除リンクにする %>
+        <%= link_to diary_reaction_path(diary, my_reaction),
+                    data: { "turbo-method": :delete },
+                    class: "flex items-center gap-1 px-2 py-1 bg-blue-100 border border-blue-300 rounded-full transition hover:bg-red-50" do %>
+          <span><%= emoji.character %></span>
+          <span class="text-xs font-bold text-blue-700"><%= count %></span>
+        <% end %>
+      <% else %>
+        <%# 他人のリアクションなら、クリックしても何も起きない（または追加するリンクにする） %>
+        <%= button_to diary_reactions_path(diary, emoji_id: emoji_id),
+                      method: :post,
+                      class: "flex items-center gap-1 px-2 py-1 bg-gray-50 border border-gray-200 rounded-full hover:bg-gray-200" do %>
+          <span><%= emoji.character %></span>
+          <span class="text-xs font-bold text-gray-500"><%= count %></span>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <%# 2. 新しくリアクションを追加するためのボタン（＋マークなど） %>
+  <details class="relative inline-block overflow-visible">
+    <summary class="list-none cursor-pointer">
+      <div class="px-3 py-1 border-2 border-dashed border-gray-300 rounded-full text-gray-400">
+        ＋
+      </div>
+    </summary>
+
+    <%# クリックするとこれが表示される %>
+    <div class="absolute bottom-full left-0 mb-2 flex bg-white border shadow-xl rounded-lg p-2 gap-2 z-50 min-w-max">
+      <% Emoji.order("RANDOM()").limit(6).each do |emoji| %>
+        <%= button_to diary_reactions_path(diary, emoji_id: emoji.id),
+                      method: :post,
+                      class: "text-xl hover:scale-125 transition" do %>
+          <%= emoji.character %>
+        <% end %>
+      <% end %>
+    </div>
+  </details>
+
+  <style>
+    /* 三角矢印を消すためのスタイル */
+    summary::-webkit-details-marker { display: none; }
+  </style>
+</div>

--- a/app/views/diaries/_reaction.html.erb
+++ b/app/views/diaries/_reaction.html.erb
@@ -28,25 +28,8 @@
     <% end %>
   </div>
 
-  <%# 2. 新しくリアクションを追加するためのボタン（＋マークなど） %>
-  <details class="relative inline-block overflow-visible">
-    <summary class="list-none cursor-pointer">
-      <div class="px-3 py-1 border-2 border-dashed border-gray-300 rounded-full text-gray-400">
-        ＋
-      </div>
-    </summary>
-
-    <%# クリックするとこれが表示される %>
-    <div class="absolute bottom-full left-0 mb-2 flex bg-white border shadow-xl rounded-lg p-2 gap-2 z-50 min-w-max">
-      <% Emoji.order("RANDOM()").limit(6).each do |emoji| %>
-        <%= button_to diary_reactions_path(diary, emoji_id: emoji.id),
-                      method: :post,
-                      class: "text-xl hover:scale-125 transition" do %>
-          <%= emoji.character %>
-        <% end %>
-      <% end %>
-    </div>
-  </details>
+  <%# 2. リアクションのパレットを表示 %>
+  <%= render 'reaction_palette', diary: diary %>
 
   <style>
     /* 三角矢印を消すためのスタイル */

--- a/app/views/diaries/_reaction_palette.html.erb
+++ b/app/views/diaries/_reaction_palette.html.erb
@@ -1,0 +1,12 @@
+<% my_reactions_count = diary.reactions.where(user_id: current_user.id).count %>
+<% if diary.user_id != current_user.id &&
+      diary.user.family_id == current_user.family_id &&
+      my_reactions_count < 5 %>
+  <details class="relative inline-block overflow-visible">
+    <summary class="list-none cursor-pointer">
+      <div class="px-3 py-1 border-2 border-dashed border-gray-300 rounded-full text-gray-400">＋</div>
+    </summary>
+
+    <%= render 'emoji_list', diary: diary %>
+  </details>
+<% end %>

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -24,17 +24,34 @@
           <th class="border-collapse border p-2">children</th>
           <td class="border-collapse border p-2">
             <% @diary.children.each do |child| %>
-              <%= link_to child.name, filter_diaries_path("child_ids[]" => child.id), data: { turbo: false }, class: "child-link" %><br/>
+<%
+                current_ids = Array.wrap(params[:child_ids]).map(&:to_s)
+                
+                if current_ids.include?(child.id.to_s)
+                  # すでに選択済みなら、そのIDを取り除く（解除リンクになる）
+                  next_ids = current_ids - [child.id.to_s]
+                else
+                  # 未選択なら、IDを追加する
+                  next_ids = current_ids + [child.id.to_s]
+                end
+              %>
+              <%= link_to child.name, filter_diaries_path(child_ids: next_ids, emoji_id: params[:emoji_id]), data: { turbo: false } %><br/>
             <% end %>
           </td>
         </tr>
         <tr>
           <th class="border-collapse border p-2">emoji's id</th>
-          <td class="border-collapse border p-2"><%= @diary.emoji.id %></td>
+          <td class="border-collapse border p-2">
+<%= @diary.emoji.id %>
+</td>
         </tr>
         <tr>
           <th class="border-collapse border p-2">emoji</th>
-          <td class="border-collapse border p-2"><%= @diary.emoji.character %></td>
+          <td class="border-collapse border p-2">
+            <%= link_to filter_diaries_path(child_ids: params[:child_ids], emoji_id: @diary.emoji.id), data: { turbo: false } do %>
+<%= @diary.emoji.character %>
+            <% end %>
+</td>
         </tr>
         <tr>
           <th class="border-collapse border p-2">body</th>

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -17,6 +17,10 @@
           <td class="border-collapse border p-2"><%= @diary.user.family_id %></td>
         </tr>
         <tr>
+          <th class="border-collapse border p-2">user's<br/>family</th>
+          <td class="border-collapse border p-2"><%= @diary.user.family.name %></td>
+        </tr>
+        <tr>
           <th class="border-collapse border p-2">user</th>
           <td class="border-collapse border p-2"><%= @diary.user.name %></td>
         </tr>
@@ -24,7 +28,7 @@
           <th class="border-collapse border p-2">children</th>
           <td class="border-collapse border p-2">
             <% @diary.children.each do |child| %>
-<%
+              <%
                 current_ids = Array.wrap(params[:child_ids]).map(&:to_s)
                 
                 if current_ids.include?(child.id.to_s)
@@ -35,23 +39,23 @@
                   next_ids = current_ids + [child.id.to_s]
                 end
               %>
-              <%= link_to child.name, filter_diaries_path(child_ids: next_ids, emoji_id: params[:emoji_id]), data: { turbo: false } %><br/>
+                <%= link_to child.name, filter_diaries_path(child_ids: next_ids, emoji_id: params[:emoji_id]), data: { turbo: false } %><br/>
             <% end %>
           </td>
         </tr>
         <tr>
           <th class="border-collapse border p-2">emoji's id</th>
           <td class="border-collapse border p-2">
-<%= @diary.emoji.id %>
-</td>
+              <%= @diary.emoji.id %>
+          </td>
         </tr>
         <tr>
           <th class="border-collapse border p-2">emoji</th>
           <td class="border-collapse border p-2">
             <%= link_to filter_diaries_path(child_ids: params[:child_ids], emoji_id: @diary.emoji.id), data: { turbo: false } do %>
-<%= @diary.emoji.character %>
+              <%= @diary.emoji.character %>
             <% end %>
-</td>
+          </td>
         </tr>
         <tr>
           <th class="border-collapse border p-2">body</th>

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -74,6 +74,45 @@
           </td>
         </tr>
         <% end %>
+        <tr>
+          <td colspan="2"  class="border-collapse border p-2">
+            <div class="flex flex-wrap gap-2 mt-4">
+              <%# 1. 既に付いているリアクションをカウントして表示 %>
+              <% @diary.reactions.group(:emoji_id).count.each do |emoji_id, count| %>
+                <% emoji = Emoji.find(emoji_id) %>
+                <button class="flex items-center gap-1 px-2 py-1 bg-gray-100 hover:bg-gray-200 border rounded-full transition">
+                  <span><%= emoji.character %></span>
+                  <span class="text-xs font-bold text-gray-600"><%= count %></span>
+                </button>
+              <% end %>
+
+              <%# 2. 新しくリアクションを追加するためのボタン（＋マークなど） %>
+              <details class="relative inline-block overflow-visible">
+                <summary class="list-none cursor-pointer">
+                  <div class="px-3 py-1 border-2 border-dashed border-gray-300 rounded-full text-gray-400">
+                    ＋
+                  </div>
+                </summary>
+
+                <%# クリックするとこれが表示される %>
+                <div class="absolute bottom-full left-0 mb-2 flex bg-white border shadow-xl rounded-lg p-2 gap-2 z-50 min-w-max">
+                  <% Emoji.order("RANDOM()").limit(6).each do |emoji| %>
+                    <%= button_to diary_reactions_path(@diary, emoji_id: emoji.id),
+                                  method: :post,
+                                  class: "text-xl hover:scale-125 transition" do %>
+                      <%= emoji.character %>
+                    <% end %>
+                  <% end %>
+                </div>
+              </details>
+
+              <style>
+                /* 三角矢印を消すためのスタイル */
+                summary::-webkit-details-marker { display: none; }
+              </style>
+            </div>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -74,45 +74,13 @@
           </td>
         </tr>
         <% end %>
+        <% if @diary.user != current_user %>
         <tr>
           <td colspan="2"  class="border-collapse border p-2">
-            <div class="flex flex-wrap gap-2 mt-4">
-              <%# 1. 既に付いているリアクションをカウントして表示 %>
-              <% @diary.reactions.group(:emoji_id).count.each do |emoji_id, count| %>
-                <% emoji = Emoji.find(emoji_id) %>
-                <button class="flex items-center gap-1 px-2 py-1 bg-gray-100 hover:bg-gray-200 border rounded-full transition">
-                  <span><%= emoji.character %></span>
-                  <span class="text-xs font-bold text-gray-600"><%= count %></span>
-                </button>
-              <% end %>
-
-              <%# 2. 新しくリアクションを追加するためのボタン（＋マークなど） %>
-              <details class="relative inline-block overflow-visible">
-                <summary class="list-none cursor-pointer">
-                  <div class="px-3 py-1 border-2 border-dashed border-gray-300 rounded-full text-gray-400">
-                    ＋
-                  </div>
-                </summary>
-
-                <%# クリックするとこれが表示される %>
-                <div class="absolute bottom-full left-0 mb-2 flex bg-white border shadow-xl rounded-lg p-2 gap-2 z-50 min-w-max">
-                  <% Emoji.order("RANDOM()").limit(6).each do |emoji| %>
-                    <%= button_to diary_reactions_path(@diary, emoji_id: emoji.id),
-                                  method: :post,
-                                  class: "text-xl hover:scale-125 transition" do %>
-                      <%= emoji.character %>
-                    <% end %>
-                  <% end %>
-                </div>
-              </details>
-
-              <style>
-                /* 三角矢印を消すためのスタイル */
-                summary::-webkit-details-marker { display: none; }
-              </style>
-            </div>
+            <%= render 'diaries/reaction', diary: @diary %>
           </td>
         </tr>
+        <% end %>
       </tbody>
     </table>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   end
 
   resources :diaries do
+    resources :reactions, only: [:create, :destroy]
     collection do
       get 'date_index'
       get 'filter'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,9 @@ Rails.application.routes.draw do
 
   resources :diaries do
     resources :reactions, only: [:create, :destroy]
+    member do
+      get :refresh_emoji
+    end
     collection do
       get 'date_index'
       get 'filter'


### PR DESCRIPTION
## 概要
自分以外の家族メンバーの日記に、絵文字でリアクションを付けたり除いたりする機能を実装

## 関連issue
#102 

## やったこと
 - 日記にリアクションを付与・除去するためのアクションを追加
 - 日記1件に対する1人当たりのリアクション数へのバリデーションを追加
 - 関連部分をパーシャル化
	 - リアクション表示部分
	 - リアクションを追加するための部分
	 - リアクションのための絵文字をランダム表示する部分
 - 自分以外の日記にリアクションが付与できるロジックをビュー側に設定
 - 自分の付けたリアクションが5つ以上になると、リアクションを追加するボタンが表示されないロジックをビュー側に設定
 - ランダム表示されるリアクション用の絵文字を更新するためのアクションを追加

## やらないこと
 - 1日ごとの日記一覧表示画面で、画面遷移をせずにリアクションを付与・除去する機能

## テスト／完了確認
 - [x] ユーザーが付与したリアクションが表示されていることを確認
	 - [x] 日記一覧表示画面
	 - [x] 日記詳細表示画面
 - [x] 自分以外の家族メンバーの日記にリアクション付与・除去できることを確認
 - [x] 5個を超えるリアクションは付与できないことを確認