### PR TITLE
Feature/#105 ヘッダー部のデザインを整える

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,12 +1,19 @@
-<div class="grid grid-cols-2 gap-2 items-center p-4 bg-sky-100">
-  <div class="text-left">
+<div class="grid grid-cols-3 gap-2 items-center p-4 bg-lime-300">
+  <div class="text-left col-span-2">
     <%=link_to image_tag('/tsumugi-logo.png', class: "max-h-[4dvh]"), root_path %>
   </div>
-  <div class="text-right">
+
+  <div>
     <% if logged_in? %>
-      <%= link_to 'ログアウト', logout_path, data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" } %>
+      <%= link_to logout_path, data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" }, class: "flex flex-col items-center gap-1 group" do %>
+        <span class="icon-[lucide--log-out] text-xl text-lime-700 transition-transform group-active:scale-95"></span>
+        <span class="text-[12px] font-bold text-lime-900">ログアウト</span>
+      <% end %>
     <% else %>
-      <%= link_to "ログイン・新規登録", auth_path %>
+      <%= link_to auth_path, data: { turbo: :false }, class: "flex flex-col items-center gap-1 group" do %>
+        <span class="icon-[lucide--log-in] text-xl text-lime-700 transition-transform group-active:scale-95"></span>
+        <span class="text-[12px] font-bold text-lime-900">ログイン・新規登録</span>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,6 @@
 <div class="grid grid-cols-3 gap-2 items-center p-4 bg-lime-300">
   <div class="text-left col-span-2">
-    <%=link_to image_tag('/tsumugi-logo.png', class: "max-h-[4dvh]"), root_path %>
+    <%=link_to image_tag('/tsumugi-logo.png', class: "max-h-[5dvh]"), root_path %>
   </div>
 
   <div>

--- a/app/views/layouts/_menu.html.erb
+++ b/app/views/layouts/_menu.html.erb
@@ -2,28 +2,28 @@
   <div id="new_article" class="flex flex-col items-center justify-center">
     <%= link_to new_diary_path, data: { turbo: false }, class: "flex flex-col items-center gap-1 group" do %>
       <span class="icon-[lucide--plus-circle] text-2xl text-amber-500 transition-transform group-active:scale-95"></span>
-      <span class="text-[10px] font-bold text-neutral-700">日記投稿</span>
+      <span class="text-[10px] font-bold text-amber-800">日記投稿</span>
     <% end %>
   </div>
 
   <div id="go_to_home" class="flex flex-col items-center justify-center">
     <%= link_to diaries_path, data: { turbo: false }, class: "flex flex-col items-center gap-1 group" do %>
       <span class="icon-[lucide--home] text-2xl text-amber-500 transition-transform group-active:scale-95"></span>
-      <span class="text-[10px] font-bold text-neutral-700">ホーム</span>
+      <span class="text-[10px] font-bold text-amber-800">ホーム</span>
     <% end %>
   </div>
 
   <div id="search" class="flex flex-col items-center justify-center">
     <%= link_to root_path, data: { turbo: false }, class: "flex flex-col items-center gap-1 group" do %>
       <span class="icon-[lucide--search] text-2xl text-amber-500 transition-transform group-active:scale-95"></span>
-      <span class="text-[10px] font-bold text-neutral-700">検索</span>
+      <span class="text-[10px] font-bold text-amber-800">検索</span>
     <% end %>
   </div>
 
   <div id="my_page" class="flex flex-col items-center justify-center">
     <%= link_to mypage_path, data: { turbo: false }, class: "flex flex-col items-center gap-1 group" do %>
       <span class="icon-[lucide--user] text-2xl text-amber-500 transition-transform group-active:scale-95"></span>
-      <span class="text-[10px] font-bold text-neutral-700">マイページ</span>
+      <span class="text-[10px] font-bold text-amber-800">マイページ</span>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
## 概要
ヘッダー部のデザインを整える

## 関連issue
#105 

## やったこと
 - ヘッダー部のデザインを変更
	 - 背景色を変更
	 - 「ログイン・新規登録」「ログアウト」ボタンにアイコンを設定
	 - ロゴの表示を少しだけ拡大
 - メニュー部の文字色をより自然なものに変更

## やらないこと
 - ヘッダー部とメニュー部以外のデザインの変更や調整

## テスト／完了確認
 - [x] ヘッダー部がスマートフォンに最適化されたデザインになっていることを確認