### PR TITLE
Feature/#108 一覧画面の日記1件当たりのパーシャルデザインを調整

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -10,18 +10,33 @@ class ReactionsController < ApplicationController
         emoji_id: params[:emoji_id]
       )
       if @reaction.save
-        redirect_back fallback_location: diaries_path, notice: "リアクションしました"
+        render_reaction_stream
       else
-        redirect_back fallback_location: diaries_path, alert: "リアクションに失敗しました"
+        render_reaction_stream
+        # redirect_back fallback_location: diary_path(@diary), alert: "リアクションに失敗しました"
       end
     else
-      redirect_back fallback_location: diaries_path, alert: "自分自身の日記にはリアクションできません"
+      render turbo_stream: turbo_stream.replace(
+        "diary_#{@diary.id}_reaction_area",
+        render_to_string(partial: 'diaries/reaction', locals: { diary: @diary })
+      )
     end
   end
 
   def destroy
     @reaction = current_user.reactions.find(params[:id])
+    @diary = @reaction.diary
     @reaction.destroy
-    redirect_back fallback_location: diaries_path, notice: "リアクションを取り消しました"
+
+    render_reaction_stream
   end
+end
+
+private
+
+def render_reaction_stream
+  render turbo_stream: turbo_stream.replace(
+    "diary_#{@diary.id}_reaction_area",
+    render_to_string(partial: 'diaries/reaction', locals: { diary: @diary })
+  )
 end

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -18,25 +18,6 @@
       <p class="text-stone-400 dark:text-stone-500 text-xs font-medium mb-2">
         <%= l(diary.created_at, format: :only_time) %>
       </p>
-      <!-- 子どもの情報 -->
-      <div class="flex flex-wrap justify-end gap-2 py-1 z-20">
-        <% diary.children.each do |child| %>
-          <%
-            current_ids = Array.wrap(params[:child_ids]).map(&:to_s)
-            
-            if current_ids.include?(child.id.to_s)
-              # すでに選択済みなら、そのIDを取り除く（解除リンクになる）
-              next_ids = current_ids - [child.id.to_s]
-            else
-              # 未選択なら、IDを追加する
-              next_ids = current_ids + [child.id.to_s]
-            end
-          %>
-          <span class="bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 text-sm font-bold px-3 py-1 rounded-full uppercase tracking-wider">
-            <%= link_to child.name, filter_diaries_path(child_ids: next_ids, emoji_id: params[:emoji_id]), data: { turbo: false } %>
-          </span>
-        <% end %>
-      </div>
     </div>
 
     <!-- ユーザーアバター-->
@@ -53,6 +34,26 @@
     </div>
   </div>
 
+  <!-- 子どもの情報 -->
+  <div class="flex flex-wrap justify-end gap-2 py-1 z-20">
+    <% diary.children.each do |child| %>
+      <%
+        current_ids = Array.wrap(params[:child_ids]).map(&:to_s)
+        
+        if current_ids.include?(child.id.to_s)
+          # すでに選択済みなら、そのIDを取り除く（解除リンクになる）
+          next_ids = current_ids - [child.id.to_s]
+        else
+          # 未選択なら、IDを追加する
+          next_ids = current_ids + [child.id.to_s]
+        end
+      %>
+      <span class="bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 text-sm font-bold px-3 py-1 rounded-full uppercase tracking-wider">
+        <%= link_to child.name, filter_diaries_path(child_ids: next_ids, emoji_id: params[:emoji_id]), data: { turbo: false } %>
+      </span>
+    <% end %>
+  </div>
+
   <!-- コンテンツ本体: 日記本文 -->
   <div class="flex flex-col flex-1 mt-1">
     <p class="text-[#4a4238] dark:text-[#dcd6ce] text-[15px] leading-relaxed font-normal whitespace-pre-wrap">
@@ -61,7 +62,7 @@
   </div>
 
   <!-- フッター: タグとリアクションボタン -->
-  <div class="flex flex-col sm:flex-row sm:items-center justify-between mt-5 gap-4">
+  <div class="flex flex-col sm:flex-row sm:items-center justify-between mt-4 gap-2">
     <!-- タグ -->
     <!-- % if diary.tags.any? % -->
       <div class="flex flex-wrap gap-2">
@@ -74,7 +75,7 @@
     <!-- % end % -->
     
     <!-- リアクションボタン -->
-    <div class="flex items-center justify-end gap-1 border-t sm:border-t-0 border-stone-100 dark:border-stone-800 pt-3 sm:pt-0 z-20">
+    <div class="flex items-center justify-end gap-1 z-20">
       <%= render 'reaction', diary: diary %>
     </div>
   </div>

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -60,7 +60,7 @@
     </p>
   </div>
 
-  <!-- フッター: タグとアクションボタン -->
+  <!-- フッター: タグとリアクションボタン -->
   <div class="flex flex-col sm:flex-row sm:items-center justify-between mt-5 gap-4">
     <!-- タグ -->
     <!-- % if diary.tags.any? % -->
@@ -73,8 +73,8 @@
       </div>
     <!-- % end % -->
     
-    <!-- アクションボタン -->
-    <div class="flex items-center justify-end gap-1 border-t sm:border-t-0 border-stone-100 dark:border-stone-800 pt-3 sm:pt-0">
+    <!-- リアクションボタン -->
+    <div class="flex items-center justify-end gap-1 border-t sm:border-t-0 border-stone-100 dark:border-stone-800 pt-3 sm:pt-0 z-10">
       <%= render 'reaction', diary: diary %>
     </div>
   </div>

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -1,7 +1,7 @@
-<article id="diary_<%= diary.id %>" class="relative flex flex-col bg-white dark:bg-surface-dark rounded-xl p-5 shadow-soft border border-stone-100 dark:border-stone-800 transition-colors">
+<article id="diary_<%= diary.id %>" class="relative flex flex-col bg-white dark:bg-surface-dark rounded-xl p-5 shadow-soft border border-stone-100 dark:border-stone-800 transition-colors z-0 hover:z-[1] transition-all">
 
   <!-- 絵文字 -->
-  <div class="absolute top-4 left-4 flex-shrink-0 z-10">
+  <div class="absolute top-4 left-4 flex-shrink-0 z-20">
     <div class="flex items-center justify-center size-16 rounded-full bg-amber-soft dark:bg-[#3d3220] text-4xl shadow-inner">
       <%= link_to filter_diaries_path(child_ids: params[:child_ids], emoji_id: diary.emoji.id), data: { turbo: false } do %>
         <%= diary.emoji.character %>
@@ -19,7 +19,7 @@
         <%= l(diary.created_at, format: :only_time) %>
       </p>
       <!-- 子どもの情報 -->
-      <div class="flex flex-wrap justify-end gap-2 py-1 z-10">
+      <div class="flex flex-wrap justify-end gap-2 py-1 z-20">
         <% diary.children.each do |child| %>
           <%
             current_ids = Array.wrap(params[:child_ids]).map(&:to_s)
@@ -74,11 +74,11 @@
     <!-- % end % -->
     
     <!-- リアクションボタン -->
-    <div class="flex items-center justify-end gap-1 border-t sm:border-t-0 border-stone-100 dark:border-stone-800 pt-3 sm:pt-0 z-10">
+    <div class="flex items-center justify-end gap-1 border-t sm:border-t-0 border-stone-100 dark:border-stone-800 pt-3 sm:pt-0 z-20">
       <%= render 'reaction', diary: diary %>
     </div>
   </div>
 
   <!-- ナビゲーション用のクリック可能なオーバーレイ-->
-  <%= link_to "", diary_path(diary), class: "absolute inset-0 z-0", data: { turbo: false } %>
+  <%= link_to "", diary_path(diary), class: "absolute inset-0 z-10", data: { turbo: false } %>
 </article>

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -17,7 +17,7 @@
         <%= l(diary.created_at, format: :only_time) %>
       </p>
       <!-- 子どもの情報 -->
-      <div class="flex flex-wrap justify-end gap-2 py-1"> <!-- justify-endで右寄せに -->
+      <div class="flex flex-wrap justify-end gap-2 py-1">
         <% diary.children.each do |child| %>
           <span class="bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 text-sm font-bold px-3 py-1 rounded-full uppercase tracking-wider">
             <%= child.name %>
@@ -29,7 +29,7 @@
     <!-- ユーザーアバター-->
     <div class="flex-shrink-0">
       <div class="relative">
-        <div class="size-12 rounded-full bg-gray-200 overflow-hidden ring-2 ring-primary/20">
+        <div class="size-10 rounded-full bg-gray-200 overflow-hidden ring-2 ring-primary/20">
           <% if diary.user.avatar.attached? %>
             <%= image_tag diary.user.avatar, class: "w-full h-full object-cover" %>
           <% else %>
@@ -61,13 +61,9 @@
     <!-- % end % -->
     
     <!-- アクションボタン -->
-    <% if diary.user != current_user %>
-      <div class="flex items-center justify-end gap-1 border-t sm:border-t-0 border-stone-100 dark:border-stone-800 pt-3 sm:pt-0">
-        <%= render 'reaction', diary: diary %>
-      </div>
-    <% else %>
-      <div class="flex-1"></div>
-    <% end %>
+    <div class="flex items-center justify-end gap-1 border-t sm:border-t-0 border-stone-100 dark:border-stone-800 pt-3 sm:pt-0">
+      <%= render 'reaction', diary: diary %>
+    </div>
   </div>
 
   <!-- ナビゲーション用のクリック可能なオーバーレイ-->

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -1,53 +1,75 @@
-<div id="diary" class="w-2/3 justify-self-center relative transition">
-  <div class="flex flex-col m-4 border rounded-md">
-    <%# 1段目：絵文字（左寄せ） %>
-    <div class="flex justify-start p-4 relative z-10">
-      <%= link_to filter_diaries_path(child_ids: params[:child_ids], emoji_id: diary.emoji.id), data: { turbo: false } do %>
-        <%= diary.emoji.character %>
-      <% end %>
+<article id="diary_<%= diary.id %>" class="relative flex flex-col bg-white dark:bg-surface-dark rounded-xl p-5 shadow-soft border border-stone-100 dark:border-stone-800 transition-colors">
+
+  <!-- 絵文字 -->
+  <div class="absolute top-4 left-4 flex-shrink-0 z-10">
+    <div class="flex items-center justify-center size-16 rounded-full bg-amber-soft dark:bg-[#3d3220] text-4xl shadow-inner">
+      <%= diary.emoji.character %>
+    </div>
+  </div>
+
+  <!-- ヘッダー: ユーザー情報、投稿時間、子どもの情報 -->
+  <div class="flex items-start justify-end mb-2 pl-24">
+    <div class="flex flex-col flex-grow text-right mr-4">
+      <!-- 投稿ユーザー -->
+      <h3 class="font-bold text-base text-[#1c170d] dark:text-white leading-tight mb-1"><%= diary.user.name %></h3>
+      <!-- 投稿時間 -->
+      <p class="text-stone-400 dark:text-stone-500 text-xs font-medium mb-2">
+        <%= l(diary.created_at, format: :only_time) %>
+      </p>
+      <!-- 子どもの情報 -->
+      <div class="flex flex-wrap justify-end gap-2 py-1"> <!-- justify-endで右寄せに -->
+        <% diary.children.each do |child| %>
+          <span class="bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 text-sm font-bold px-3 py-1 rounded-full uppercase tracking-wider">
+            <%= child.name %>
+          </span>
+        <% end %>
+      </div>
     </div>
 
-    <%# 2段目：カテゴリ、タグ %>
-    <div class="flex justify-start gap-2 px-6 relative z-10">
-      <% diary.children.each do |child| %>
-        <%
-          current_ids = Array.wrap(params[:child_ids]).map(&:to_s)
-          
-          if current_ids.include?(child.id.to_s)
-            # すでに選択済みなら、そのIDを取り除く（解除リンクになる）
-            next_ids = current_ids - [child.id.to_s]
-          else
-            # 未選択なら、IDを追加する
-            next_ids = current_ids + [child.id.to_s]
-          end
-        %>
-        <div class="border p-2">
-          <%= link_to child.name, filter_diaries_path(child_ids: next_ids, emoji_id: params[:emoji_id]), data: { turbo: false } %>
+    <!-- ユーザーアバター-->
+    <div class="flex-shrink-0">
+      <div class="relative">
+        <div class="size-12 rounded-full bg-gray-200 overflow-hidden ring-2 ring-primary/20">
+          <% if diary.user.avatar.attached? %>
+            <%= image_tag diary.user.avatar, class: "w-full h-full object-cover" %>
+          <% else %>
+            <img alt="<%= diary.user.name %> portrait" class="w-full h-full object-cover" src="https://via.placeholder.com/48/F5A30A/FFFFFF?text=<%= diary.user.name.first %>" />
+          <% end %>
         </div>
-      <% end %>
-      <div class="border p-2 relative z-10">タグ</div>
+      </div>
     </div>
+  </div>
 
-    <%# 3段目：ID、家族ID、家族名、ユーザー名 %>
-    <div class="flex justify-center m-2">
-      <div class="p-2">id：<%= diary.id %></div>
-      <div class="p-2">family_id：<%= diary.user.family_id %></div>
-      <div class="p-2">family name：<%= diary.user.family.name %></div>
-      <div class="p-2">user：<%= diary.user.name %></div>
-    </div>
-
-    <%# 4段目：本文 %>
-    <div class="flex justify-start m-2 px-4 py-2">
+  <!-- コンテンツ本体: 日記本文 -->
+  <div class="flex flex-col flex-1 mt-1">
+    <p class="text-[#4a4238] dark:text-[#dcd6ce] text-[15px] leading-relaxed font-normal whitespace-pre-wrap">
       <%= diary.body %>
-    </div>
+    </p>
+  </div>
 
+  <!-- フッター: タグとアクションボタン -->
+  <div class="flex flex-col sm:flex-row sm:items-center justify-between mt-5 gap-4">
+    <!-- タグ -->
+    <!-- % if diary.tags.any? % -->
+      <div class="flex flex-wrap gap-2">
+        <!-- % diary.tags.each do |tag| % -->
+          <div class="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-lime-100 dark:bg-lime-900/30 text-lime-800 dark:text-lime-200 transition-colors">
+            <span class="text-xs font-semibold"># タグ<%# = tag.name %></span>
+          </div>
+        <!-- % end % -->
+      </div>
+    <!-- % end % -->
+    
+    <!-- アクションボタン -->
     <% if diary.user != current_user %>
-    <div class="flex justify-end m-2 px-4 py-2">
-      <%= render 'reaction', diary: diary %>
-    </div>
+      <div class="flex items-center justify-end gap-1 border-t sm:border-t-0 border-stone-100 dark:border-stone-800 pt-3 sm:pt-0">
+        <%= render 'reaction', diary: diary %>
+      </div>
+    <% else %>
+      <div class="flex-1"></div>
     <% end %>
   </div>
-  <%= link_to "", diary_path(diary),
-      class: "absolute inset-0 z-0",
-      data: { turbo: false } %>
-</div>
+
+  <!-- ナビゲーション用のクリック可能なオーバーレイ-->
+  <%= link_to "", diary_path(diary), class: "absolute inset-0 z-0 rounded-2xl", data: { turbo: false } %>
+</article>

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -3,7 +3,9 @@
   <!-- 絵文字 -->
   <div class="absolute top-4 left-4 flex-shrink-0 z-10">
     <div class="flex items-center justify-center size-16 rounded-full bg-amber-soft dark:bg-[#3d3220] text-4xl shadow-inner">
-      <%= diary.emoji.character %>
+      <%= link_to filter_diaries_path(child_ids: params[:child_ids], emoji_id: diary.emoji.id), data: { turbo: false } do %>
+        <%= diary.emoji.character %>
+      <% end %>
     </div>
   </div>
 
@@ -17,10 +19,21 @@
         <%= l(diary.created_at, format: :only_time) %>
       </p>
       <!-- 子どもの情報 -->
-      <div class="flex flex-wrap justify-end gap-2 py-1">
+      <div class="flex flex-wrap justify-end gap-2 py-1 z-10">
         <% diary.children.each do |child| %>
+          <%
+            current_ids = Array.wrap(params[:child_ids]).map(&:to_s)
+            
+            if current_ids.include?(child.id.to_s)
+              # すでに選択済みなら、そのIDを取り除く（解除リンクになる）
+              next_ids = current_ids - [child.id.to_s]
+            else
+              # 未選択なら、IDを追加する
+              next_ids = current_ids + [child.id.to_s]
+            end
+          %>
           <span class="bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 text-sm font-bold px-3 py-1 rounded-full uppercase tracking-wider">
-            <%= child.name %>
+            <%= link_to child.name, filter_diaries_path(child_ids: next_ids, emoji_id: params[:emoji_id]), data: { turbo: false } %>
           </span>
         <% end %>
       </div>
@@ -67,5 +80,5 @@
   </div>
 
   <!-- ナビゲーション用のクリック可能なオーバーレイ-->
-  <%= link_to "", diary_path(diary), class: "absolute inset-0 z-0 rounded-2xl", data: { turbo: false } %>
+  <%= link_to "", diary_path(diary), class: "absolute inset-0 z-0", data: { turbo: false } %>
 </article>

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -10,7 +10,7 @@
   </div>
 
   <!-- ヘッダー: ユーザー情報、投稿時間、子どもの情報 -->
-  <div class="flex items-start justify-end mb-2 pl-24">
+  <div class="flex items-start justify-end mb-2 pl-12">
     <div class="flex flex-col flex-grow text-right mr-4">
       <!-- 投稿ユーザー -->
       <h3 class="font-bold text-base text-[#1c170d] dark:text-white leading-tight mb-1"><%= diary.user.name %></h3>

--- a/app/views/diaries/_emoji_list.html.erb
+++ b/app/views/diaries/_emoji_list.html.erb
@@ -15,9 +15,9 @@
     <div class="w-px h-6 bg-neutral-200 mx-1"></div>
 
     <%= link_to refresh_emoji_diary_path(diary),
-                class: "w-10 h-10 flex items-center justify-center text-neutral-400 hover:text-amber-500 transition-colors",
+                class: "w-10 h-10 flex items-center justify-center text-amber-700 hover:bg-amber-50 active:scale-95 transition-transform ml-1 transition-colors",
                 title: "リフレッシュ" do %>
-      <span class="icon-[lucide--refresh-cw] w-5 h-5"></span>
+      <span class="icon-[lucide--rotate-ccw] w-5 h-5"></span>
     <% end %>
   </div>
 <% end %>

--- a/app/views/diaries/_emoji_list.html.erb
+++ b/app/views/diaries/_emoji_list.html.erb
@@ -1,9 +1,23 @@
+<%# 絵文字選択リスト：モバイル端末で押しやすいパレット形式、影と丸みで浮遊感を演出 %>
 <%= turbo_frame_tag "emoji_palette_#{diary.id}" do %>
-  <div class="absolute bottom-full left-0 mb-2 flex bg-white border shadow-xl rounded-lg p-2 gap-2 z-50 min-w-max items-center">
-    <% Emoji.order("RANDOM()").limit(6).each do |emoji| %>
-      <%= button_to emoji.character, diary_reactions_path(diary, emoji_id: emoji.id),
-                    method: :post, data: { turbo_frame: "_top" } %>
+  <div class="absolute bottom-full left-0 mb-3 flex items-center bg-white border border-neutral-200 shadow-xl rounded-2xl p-2.5 gap-2 z-50 min-w-max animate-in fade-in slide-in-from-bottom-2 duration-200">
+    <div class="flex items-center gap-1.5">
+      <% Emoji.order("RANDOM()").limit(5).each do |emoji| %>
+        <%= button_to diary_reactions_path(diary, emoji_id: emoji.id),
+                      method: :post,
+                      data: { turbo_frame: "_top" },
+                      class: "w-10 h-10 flex items-center justify-center text-xl rounded-xl hover:bg-amber-50 transition-colors active:scale-90" do %>
+          <%= emoji.character %>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div class="w-px h-6 bg-neutral-200 mx-1"></div>
+
+    <%= link_to refresh_emoji_diary_path(diary),
+                class: "w-10 h-10 flex items-center justify-center text-neutral-400 hover:text-amber-500 transition-colors",
+                title: "リフレッシュ" do %>
+      <span class="icon-[lucide--refresh-cw] w-5 h-5"></span>
     <% end %>
-    <%= link_to "↻", refresh_emoji_diary_path(diary), class: "ml-2 text-gray-400 hover:text-blue-500 text-sm" %>
   </div>
 <% end %>

--- a/app/views/diaries/_emoji_list.html.erb
+++ b/app/views/diaries/_emoji_list.html.erb
@@ -1,22 +1,31 @@
 <%= turbo_frame_tag "emoji_palette_#{diary.id}" do %>
-  <div class="absolute bottom-full left-0 mb-3 flex items-center bg-white border border-neutral-200 shadow-xl rounded-2xl p-2.5 gap-2 z-50 min-w-max animate-in fade-in slide-in-from-bottom-2 duration-200">
-    <div class="flex items-center gap-1.5">
-      <% Emoji.order("RANDOM()").limit(5).each do |emoji| %>
+  <div class="fixed inset-0 z-80 bg-black/20 backdrop-blur-[2px]" 
+      onclick="this.closest('details').removeAttribute('open')"></div>
+
+  <%# パレット本体 %>
+  <div class="fixed bottom-0 left-0 right-0 mb-0 flex items-center justify-between bg-white border-t border-neutral-200 shadow-[0_-8px_30px_rgb(0,0,0,0.15)] rounded-t-3xl p-4 z-90 animate-in fade-in slide-in-from-bottom-full duration-300">
+    
+    <div class="flex items-center gap-3 overflow-x-auto pb-2 no-scrollbar">
+      <% Emoji.order("RANDOM()").limit(6).each do |emoji| %>
         <%= button_to diary_reactions_path(diary, emoji_id: emoji.id),
                       method: :post,
-                      data: { "turbo_frame": "diary_#{diary.id}_reaction_area", "turbo_stream": true },
-                      class: "w-10 h-10 flex items-center justify-center text-xl rounded-xl hover:bg-amber-50 transition-colors active:scale-90" do %>
+                      data: {
+                        turbo_frame: "diary_#{diary.id}_reaction_area",
+                        turbo_stream: true
+                      },
+                      onclick: "this.closest('details').removeAttribute('open')",
+                      class: "w-10 h-10 flex items-center justify-center text-2xl rounded-2xl hover:bg-amber-50 active:scale-90 transition-all bg-neutral-50 border border-neutral-100" do %>
           <%= emoji.character %>
         <% end %>
       <% end %>
     </div>
 
-    <div class="w-px h-6 bg-neutral-200 mx-1"></div>
-
-    <%= link_to refresh_emoji_diary_path(diary),
-                class: "w-10 h-10 flex items-center justify-center text-amber-700 hover:bg-amber-50 active:scale-95 transition-transform ml-1 transition-colors",
-                title: "リフレッシュ" do %>
-      <span class="icon-[lucide--rotate-ccw] w-5 h-5"></span>
-    <% end %>
+    <div class="flex items-center border-l border-neutral-200 pl-2 ml-1">
+      <%= link_to refresh_emoji_diary_path(diary),
+                  class: "w-10 h-10 flex items-center justify-center text-amber-700 hover:bg-amber-50 active:rotate-180 transition-all duration-500",
+                  title: "リフレッシュ" do %>
+        <span class="icon-[lucide--rotate-ccw] w-5 h-5"></span>
+      <% end %>
+    </div>
   </div>
 <% end %>

--- a/app/views/diaries/_emoji_list.html.erb
+++ b/app/views/diaries/_emoji_list.html.erb
@@ -1,11 +1,10 @@
-<%# 絵文字選択リスト：モバイル端末で押しやすいパレット形式、影と丸みで浮遊感を演出 %>
 <%= turbo_frame_tag "emoji_palette_#{diary.id}" do %>
   <div class="absolute bottom-full left-0 mb-3 flex items-center bg-white border border-neutral-200 shadow-xl rounded-2xl p-2.5 gap-2 z-50 min-w-max animate-in fade-in slide-in-from-bottom-2 duration-200">
     <div class="flex items-center gap-1.5">
       <% Emoji.order("RANDOM()").limit(5).each do |emoji| %>
         <%= button_to diary_reactions_path(diary, emoji_id: emoji.id),
                       method: :post,
-                      data: { turbo_frame: "_top" },
+                      data: { "turbo_frame": "diary_#{diary.id}_reaction_area", "turbo_stream": true },
                       class: "w-10 h-10 flex items-center justify-center text-xl rounded-xl hover:bg-amber-50 transition-colors active:scale-90" do %>
           <%= emoji.character %>
         <% end %>

--- a/app/views/diaries/_reaction.html.erb
+++ b/app/views/diaries/_reaction.html.erb
@@ -1,40 +1,26 @@
-<div class="flex flex-wrap items-center gap-2 mt-4">
-  <div class="flex flex-wrap items-center gap-2">
-    <%# 1. すでに付いているリアクションを絵文字ごとにまとめて表示 %>
+<div class="flex flex-wrap gap-2 mt-4 items-center">
+  <div class="flex flex-wrap gap-2">
+    <%# 日記に付いているリアクションを「絵文字ごと」にまとめてループ %>
     <% diary.reactions.group(:emoji_id).count.each do |emoji_id, count| %>
-      <%
-        emoji = Emoji.find(emoji_id)
-        my_reaction = diary.reactions.find_by(emoji_id: emoji_id, user_id: current_user.id)
-      %>
-
+      <% emoji = Emoji.find(emoji_id)
+        # 自分がこの日記の、この絵文字にリアクションしているか探す
+        my_reaction = diary.reactions.find_by(emoji_id: emoji_id, user_id: current_user.id) %>
       <% if my_reaction %>
-        <%# 自分のリアクション：Amber背景で強調 %>
-        <%= link_to diary_reaction_path(diary, my_reaction),
-                    data: { "turbo-method": :delete },
-                    class: "inline-flex items-center gap-1.5 px-3 py-1 bg-amber-100 border border-amber-300 rounded-full transition-all hover:bg-amber-200 active:scale-95" do %>
-          <span class="text-lg"><%= emoji.character %></span>
-          <span class="text-xs font-bold text-amber-800"><%= count %></span>
+      <%# 自分のリアクションなら、DELETEメソッドで削除リンクにする（アクティブなスタイル） %>
+        <%= link_to diary_reaction_path(diary, my_reaction), data: { "turbo-method": :delete }, class: "flex items-center gap-1 px-3 py-1.5 bg-rose-100 border border-rose-300 rounded-full transition-all hover:bg-rose-300 shadow-sm active:scale-95" do %>
+          <span class="text-base"><%= emoji.character %></span>
+          <span class="text-xs font-bold text-rose-800"><%= count %></span>
         <% end %>
       <% else %>
-        <%# 他人のリアクション：控えめなスタイル、クリックで追加 %>
-        <%= button_to diary_reactions_path(diary, emoji_id: emoji_id),
-                      method: :post,
-                      class: "inline-flex items-center gap-1.5 px-3 py-1 bg-white border border-neutral-200 rounded-full transition-all hover:bg-neutral-50 active:scale-95 shadow-sm" do %>
-          <span class="text-lg"><%= emoji.character %></span>
-          <span class="text-xs font-bold text-neutral-600"><%= count %></span>
+        <%# 他人のリアクション（または自分がまだしていないリアクション）なら、POSTメソッドで追加リンクにする（非アクティブなスタイル） %>
+        <%= button_to diary_reactions_path(diary, emoji_id: emoji.id), method: :post, class: "flex items-center gap-1 px-3 py-1.5 bg-amber-100 border border-amber-200 rounded-full transition-all hover:bg-amber-200 shadow-sm active:scale-95" do %>
+          <span class="text-base"><%= emoji.character %></span>
+          <span class="text-xs font-bold text-amber-700"><%= count %></span>
         <% end %>
       <% end %>
     <% end %>
   </div>
-
-  <%# 2. リアクション追加パレット %>
-  <% if diary.user != current_user %>
-    <%= render 'reaction_palette', diary: diary %>
-  <% end %>
-
-  <style>
-    /* Detailsの三角矢印を非表示にするための共通スタイル */
-    summary::-webkit-details-marker { display: none; }
-    summary { list-style: none; }
-  </style>
+  
+  <%# 2. リアクションのパレットを表示 %>
+  <%= render 'reaction_palette', diary: diary %>
 </div>

--- a/app/views/diaries/_reaction.html.erb
+++ b/app/views/diaries/_reaction.html.erb
@@ -1,38 +1,40 @@
-<div class="flex flex-wrap gap-2 mt-4">
-  <div class="flex flex-wrap gap-2 mt-2">
-    <%# 日記に付いているリアクションを「絵文字ごと」にまとめてループ %>
+<div class="flex flex-wrap items-center gap-2 mt-4">
+  <div class="flex flex-wrap items-center gap-2">
+    <%# 1. すでに付いているリアクションを絵文字ごとにまとめて表示 %>
     <% diary.reactions.group(:emoji_id).count.each do |emoji_id, count| %>
       <%
         emoji = Emoji.find(emoji_id)
-        # 自分がこの日記の、この絵文字にリアクションしているか探す
         my_reaction = diary.reactions.find_by(emoji_id: emoji_id, user_id: current_user.id)
       %>
 
       <% if my_reaction %>
-        <%# 自分のリアクションなら、DELETEメソッドで削除リンクにする %>
+        <%# 自分のリアクション：Amber背景で強調 %>
         <%= link_to diary_reaction_path(diary, my_reaction),
                     data: { "turbo-method": :delete },
-                    class: "flex items-center gap-1 px-2 py-1 bg-blue-100 border border-blue-300 rounded-full transition hover:bg-red-50" do %>
-          <span><%= emoji.character %></span>
-          <span class="text-xs font-bold text-blue-700"><%= count %></span>
+                    class: "inline-flex items-center gap-1.5 px-3 py-1 bg-amber-100 border border-amber-300 rounded-full transition-all hover:bg-amber-200 active:scale-95" do %>
+          <span class="text-lg"><%= emoji.character %></span>
+          <span class="text-xs font-bold text-amber-800"><%= count %></span>
         <% end %>
       <% else %>
-        <%# 他人のリアクションなら、クリックしても何も起きない（または追加するリンクにする） %>
+        <%# 他人のリアクション：控えめなスタイル、クリックで追加 %>
         <%= button_to diary_reactions_path(diary, emoji_id: emoji_id),
                       method: :post,
-                      class: "flex items-center gap-1 px-2 py-1 bg-gray-50 border border-gray-200 rounded-full hover:bg-gray-200" do %>
-          <span><%= emoji.character %></span>
-          <span class="text-xs font-bold text-gray-500"><%= count %></span>
+                      class: "inline-flex items-center gap-1.5 px-3 py-1 bg-white border border-neutral-200 rounded-full transition-all hover:bg-neutral-50 active:scale-95 shadow-sm" do %>
+          <span class="text-lg"><%= emoji.character %></span>
+          <span class="text-xs font-bold text-neutral-600"><%= count %></span>
         <% end %>
       <% end %>
     <% end %>
   </div>
 
-  <%# 2. リアクションのパレットを表示 %>
-  <%= render 'reaction_palette', diary: diary %>
+  <%# 2. リアクション追加パレット %>
+  <% if diary.user != current_user %>
+    <%= render 'reaction_palette', diary: diary %>
+  <% end %>
 
   <style>
-    /* 三角矢印を消すためのスタイル */
+    /* Detailsの三角矢印を非表示にするための共通スタイル */
     summary::-webkit-details-marker { display: none; }
+    summary { list-style: none; }
   </style>
 </div>

--- a/app/views/diaries/_reaction.html.erb
+++ b/app/views/diaries/_reaction.html.erb
@@ -1,3 +1,4 @@
+<%= turbo_frame_tag "diary_#{diary.id}_reaction_area" do %>
 <div class="flex flex-wrap gap-2 mt-4 items-center">
   <div class="flex flex-wrap gap-2">
     <%# 日記に付いているリアクションを「絵文字ごと」にまとめてループ %>
@@ -7,13 +8,13 @@
         my_reaction = diary.reactions.find_by(emoji_id: emoji_id, user_id: current_user.id) %>
       <% if my_reaction %>
       <%# 自分のリアクションなら、DELETEメソッドで削除リンクにする（アクティブなスタイル） %>
-        <%= link_to diary_reaction_path(diary, my_reaction), data: { "turbo-method": :delete }, class: "flex items-center gap-1 px-3 py-1.5 bg-rose-100 border border-rose-300 rounded-full transition-all hover:bg-rose-300 shadow-sm active:scale-95" do %>
+        <%= button_to diary_reaction_path(diary, my_reaction), method: :delete, data: { turbo_frame: "diary_#{diary.id}_reaction_area" }, class: "flex items-center gap-1 px-3 py-1.5 bg-rose-100 border border-rose-300 rounded-full transition-all hover:bg-rose-300 shadow-sm active:scale-95" do %>
           <span class="text-base"><%= emoji.character %></span>
           <span class="text-xs font-bold text-rose-800"><%= count %></span>
         <% end %>
       <% else %>
         <%# 他人のリアクション（または自分がまだしていないリアクション）なら、POSTメソッドで追加リンクにする（非アクティブなスタイル） %>
-        <%= button_to diary_reactions_path(diary, emoji_id: emoji.id), method: :post, class: "flex items-center gap-1 px-3 py-1.5 bg-amber-100 border border-amber-200 rounded-full transition-all hover:bg-amber-200 shadow-sm active:scale-95" do %>
+        <%= button_to diary_reactions_path(diary, emoji_id: emoji.id), method: :post,　data: { turbo_frame: "diary_#{diary.id}_reaction_area" }, class: "flex items-center gap-1 px-3 py-1.5 bg-amber-100 border border-amber-200 rounded-full transition-all hover:bg-amber-200 shadow-sm active:scale-95" do %>
           <span class="text-base"><%= emoji.character %></span>
           <span class="text-xs font-bold text-amber-700"><%= count %></span>
         <% end %>
@@ -22,5 +23,6 @@
   </div>
   
   <%# 2. リアクションのパレットを表示 %>
-  <%= render 'reaction_palette', diary: diary %>
+  <%= render 'diaries/reaction_palette', diary: diary %>
 </div>
+<% end %>

--- a/app/views/diaries/_reaction_palette.html.erb
+++ b/app/views/diaries/_reaction_palette.html.erb
@@ -1,17 +1,12 @@
-<%# リアクション追加のトリガーデザイン：モバイル向けに押しやすいサイズとスタイルに改善 %>
 <% my_reactions_count = diary.reactions.where(user_id: current_user.id).count %>
-
-<% if diary.user_id != current_user.id &&
-      diary.user.family_id == current_user.family_id &&
-      my_reactions_count < 5 %>
-  <details class="relative inline-block overflow-visible group">
-    <summary class="cursor-pointer outline-none">
-      <div class="inline-flex items-center justify-center w-8 h-8 border-2 border-dashed border-neutral-300 rounded-full text-neutral-400 transition-colors group-hover:border-amber-400 group-hover:text-amber-500">
-        <span class="icon-[lucide--plus] w-5 h-5"></span>
-      </div>
-    </summary>
-
-    <%# 絵文字リストのポップアップを表示 %>
-    <%= render 'emoji_list', diary: diary %>
-  </details>
-<% end %>
+  <% if diary.user_id != current_user.id && diary.user.family_id == current_user.family_id && my_reactions_count < 5 %>
+    <details class="relative inline-block overflow-visible group">
+      <!-- groupクラスを追加 -->
+      <summary class="list-none cursor-pointer flex items-center justify-center size-9 rounded-full bg-lime-100 border border-lime-300 text-lime-700 hover:bg-lime-200 transition-all shadow-sm active:scale-95">
+        <span class="icon-[lucide--plus] text-lg"></span>
+        <!-- アイコンに変更 -->
+      </summary>
+    
+      <%= render 'emoji_list', diary: diary %>
+    </details>
+  <% end %>

--- a/app/views/diaries/_reaction_palette.html.erb
+++ b/app/views/diaries/_reaction_palette.html.erb
@@ -7,6 +7,6 @@
         <!-- アイコンに変更 -->
       </summary>
     
-      <%= render 'emoji_list', diary: diary %>
+      <%= render 'diaries/emoji_list', diary: diary %>
     </details>
   <% end %>

--- a/app/views/diaries/_reaction_palette.html.erb
+++ b/app/views/diaries/_reaction_palette.html.erb
@@ -1,12 +1,17 @@
+<%# リアクション追加のトリガーデザイン：モバイル向けに押しやすいサイズとスタイルに改善 %>
 <% my_reactions_count = diary.reactions.where(user_id: current_user.id).count %>
+
 <% if diary.user_id != current_user.id &&
       diary.user.family_id == current_user.family_id &&
       my_reactions_count < 5 %>
-  <details class="relative inline-block overflow-visible">
-    <summary class="list-none cursor-pointer">
-      <div class="px-3 py-1 border-2 border-dashed border-gray-300 rounded-full text-gray-400">＋</div>
+  <details class="relative inline-block overflow-visible group">
+    <summary class="cursor-pointer outline-none">
+      <div class="inline-flex items-center justify-center w-8 h-8 border-2 border-dashed border-neutral-300 rounded-full text-neutral-400 transition-colors group-hover:border-amber-400 group-hover:text-amber-500">
+        <span class="icon-[lucide--plus] w-5 h-5"></span>
+      </div>
     </summary>
 
+    <%# 絵文字リストのポップアップを表示 %>
     <%= render 'emoji_list', diary: diary %>
   </details>
 <% end %>

--- a/app/views/diaries/_reaction_palette.html.erb
+++ b/app/views/diaries/_reaction_palette.html.erb
@@ -1,12 +1,17 @@
 <% my_reactions_count = diary.reactions.where(user_id: current_user.id).count %>
-  <% if diary.user_id != current_user.id && diary.user.family_id == current_user.family_id && my_reactions_count < 5 %>
-    <details class="relative inline-block overflow-visible group">
-      <!-- groupクラスを追加 -->
-      <summary class="list-none cursor-pointer flex items-center justify-center size-9 rounded-full bg-lime-100 border border-lime-300 text-lime-700 hover:bg-lime-200 transition-all shadow-sm active:scale-95">
-        <span class="icon-[lucide--plus] text-lg"></span>
-        <!-- アイコンに変更 -->
-      </summary>
-    
-      <%= render 'diaries/emoji_list', diary: diary %>
-    </details>
-  <% end %>
+<% if diary.user_id != current_user.id && diary.user.family_id == current_user.family_id && my_reactions_count < 5 %>
+  <style>
+    #diary_<%= diary.id %>:has(details[open]) {
+      z-index: 50 !important;
+    }
+  </style>
+  <details class="relative inline-block overflow-visible group">
+    <!-- groupクラスを追加 -->
+    <summary class="list-none cursor-pointer flex items-center justify-center size-9 rounded-full bg-lime-100 border border-lime-300 text-lime-700 hover:bg-lime-200 transition-all shadow-sm active:scale-95">
+      <span class="icon-[lucide--plus] text-lg"></span>
+      <!-- アイコンに変更 -->
+    </summary>
+  
+    <%= render 'diaries/emoji_list', diary: diary %>
+  </details>
+<% end %>

--- a/app/views/diaries/date_index.html.erb
+++ b/app/views/diaries/date_index.html.erb
@@ -1,15 +1,25 @@
-<div id="date_index" class="text-center">
-  <h1 class="text-3xl font-bold m-6"><%= l(@date.to_date, format: :long) %>の日記</h1>
+<div id="date_index" class="min-h-screen bg-lime-50 pb-20">
+  <div class="px-4 py-6">
+    <h1 class="text-2xl font-bold text-amber-900 text-center mb-6">
+      <%= l(@date.to_date, format: :long) %>の日記
+    </h1>
 
-  <% if @diaries.any? %>
-    <%= render @diaries %>
-  <% else %>
-    <div>
-      <p>日記はありません。</p>
+    <% if @diaries.any? %>
+      <div class="flex flex-col gap-4">
+        <%= render @diaries %>
+      </div>
+    <% else %>
+      <div class="flex flex-col items-center justify-center py-12">
+        <p class="text-muted-foreground text-center">日記はありません。</p>
+      </div>
+    <% end %>
+
+    <div class="mt-8 text-center">
+      <%= link_to diaries_path,
+          class: "inline-flex items-center justify-center px-6 py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:opacity-90 transition-opacity",
+          data: { turbo: false } do %>
+        カレンダーに戻る
+      <% end %>
     </div>
-  <% end %>
-
-  <div class="my-8">
-    <%= link_to "カレンダーに戻る", diaries_path, data: { turbo: false } %>
   </div>
 </div>

--- a/app/views/diaries/filter.html.erb
+++ b/app/views/diaries/filter.html.erb
@@ -1,51 +1,56 @@
-<div id="filter_diaries" class="text-center">
-  <h1 class="text-3xl font-bold mt-6">日記を絞り込む</h1>
+<div id="filter_diaries" class="min-h-screen bg-lime-50 pb-20">
+  <div class="px-4 py-6">
+    <h1 class="text-2xl font-bold text-amber-900 text-center mb-6">日記を絞り込む</h1>
 
-  <div class="flex flex-wrap justify-center gap-2 my-6">
-    <% if @selected_children.present? || @selected_emoji.present? %>
-      
-      <% if @selected_children.present? %>
-        <%# --- 子どものバッジ表示 --- %>
-        <% @selected_children.each do |child| %>
-          <div class="flex items-center border border-blue-500 bg-blue-50 px-3 py-1 rounded-full text-blue-700 shadow-sm">
-            <%
-              remaining_child_ids = Array.wrap(params[:child_ids]) - [child.id.to_s]
-            %>
-            <%= link_to filter_diaries_path(child_ids: remaining_child_ids, emoji_id: params[:emoji_id]),
+    <div class="flex flex-wrap justify-center gap-2 my-6">
+      <% if @selected_children.present? || @selected_emoji.present? %>
+        
+        <% if @selected_children.present? %>
+          <%# --- 子どものバッジ表示 --- %>
+          <% @selected_children.each do |child| %>
+            <div class="flex items-center border border-blue-500 bg-blue-50 px-3 py-1 rounded-full text-blue-700 shadow-sm">
+              <%
+                remaining_child_ids = Array.wrap(params[:child_ids]) - [child.id.to_s]
+              %>
+              <%= link_to filter_diaries_path(child_ids: remaining_child_ids, emoji_id: params[:emoji_id]),
+                          data: { turbo: false }, class: "flex items-center hover:opacity-70" do %>
+                <span class="mr-1">✕</span>
+                <span><%= child.name %></span>
+              <% end %>
+            </div>
+          <% end %>
+        <% end %>
+        
+        <%# --- 絵文字のバッジ表示 --- %>
+        <% if @selected_emoji.present? %>
+          <div class="flex items-center border border-yellow-500 bg-yellow-50 px-3 py-1 rounded-full text-lg shadow-sm">
+            <%# クリックで絵文字を解除（emoji_idをnilにするが、child_idsは維持） %>
+            <%= link_to filter_diaries_path(child_ids: params[:child_ids], emoji_id: nil), 
                         data: { turbo: false }, class: "flex items-center hover:opacity-70" do %>
-              <span class="mr-1">✕</span>
-              <span><%= child.name %></span>
+              <span class="mr-2 text-sm text-yellow-700">✕</span>
+              <span><%= @selected_emoji.character %></span>
             <% end %>
           </div>
         <% end %>
+
+        <%# --- すべてクリアボタン（あると親切） --- %>
+        <div class="ml-4 flex items-center">
+          <%= link_to "クリア", filter_diaries_path, class: "text-sm text-gray-500 underline hover:text-gray-700" %>
+        </div>
+
       <% end %>
-      
-      <%# --- 絵文字のバッジ表示 --- %>
-      <% if @selected_emoji.present? %>
-        <div class="flex items-center border border-yellow-500 bg-yellow-50 px-3 py-1 rounded-full text-lg shadow-sm">
-          <%# クリックで絵文字を解除（emoji_idをnilにするが、child_idsは維持） %>
-          <%= link_to filter_diaries_path(child_ids: params[:child_ids], emoji_id: nil), 
-                      data: { turbo: false }, class: "flex items-center hover:opacity-70" do %>
-            <span class="mr-2 text-sm text-yellow-700">✕</span>
-            <span><%= @selected_emoji.character %></span>
-          <% end %>
+    </div>
+
+    <div class="diary-list">
+      <% if @diaries.any? %>
+        <div class="flex flex-col gap-4">
+          <%= render @diaries %>
+        </div>
+      <% else %>
+        <div class="flex flex-col items-center justify-center py-12">
+          <p class="text-muted-foreground text-center">該当する日記はありません。</p>
         </div>
       <% end %>
-
-      <%# --- すべてクリアボタン（あると親切） --- %>
-      <div class="ml-4 flex items-center">
-        <%= link_to "クリア", filter_diaries_path, class: "text-sm text-gray-500 underline hover:text-gray-700" %>
-      </div>
-
-    <% end %>
+    </div>
   </div>
-
-  <div class="diary-list">
-    <% if @diaries.any? %>
-      <%= render @diaries %>
-    <% else %>
-      <p>該当する日記はありません。</p>
-    <% end %>
-  </div>
-
 </div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -16,7 +16,7 @@
       <div class="flex flex-row items-end items-center space-x-6">
         <div id="x-link" class="basis-2xs self-center">
           <%= link_to root_path, class: "text-lime-900 transition-colors", aria: { label: "X (Twitter)" } do %>
-            <span class="icon-[lucide--twitter] text-3xl" aria-hidden="true"></span>
+            <span class="icon-[simple-icons--x] text-3xl" aria-hidden="true"></span>
           <% end %>
         </div>
         <div id="note-link" class="basis-2xs">

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -9,12 +9,8 @@
 
     <%# 下段: 右寄せコピーライトとSNS %>
     <div class="flex flex-col items-end space-y-4 text-right">
-      <p class="text-sm text-lime-900">
-        &copy; <%= Time.current.year %> Omoide tsumugi.
-      </p>
-      
-      <div class="flex flex-row items-end items-center space-x-6">
-        <div id="x-link" class="basis-2xs self-center">
+      <div class="flex flex-row items-end space-x-6">
+        <div id="x-link" class="basis-2xs">
           <%= link_to root_path, class: "text-lime-900 transition-colors", aria: { label: "X (Twitter)" } do %>
             <span class="icon-[simple-icons--x] text-3xl" aria-hidden="true"></span>
           <% end %>
@@ -23,6 +19,9 @@
           <%= link_to image_tag('/note-logo.png'), root_path, aria: { label: "note" } %>
         </div>
       </div>
+      <p class="text-sm text-lime-900">
+        &copy; <%= Time.current.year %> Omoide tsumugi.
+      </p>
     </div>
   </div>
 </footer>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,6 @@
 <div class="grid grid-cols-3 gap-2 items-center p-4 bg-lime-300">
   <div class="text-left col-span-2">
-    <%=link_to image_tag('/tsumugi-logo.png', class: "max-h-[5dvh]"), root_path %>
+    <%=link_to image_tag('/tsumugi-logo.png', class: "max-w-4/5 md:w-1/2 lg:w-1/3 object-contain"), root_path %>
   </div>
 
   <div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,8 +18,11 @@
       <%= render 'layouts/header' %>
     </div>
     <div id="main" class="overflow-y-auto">
+      <div id="flash_messages" class="fixed top-[10dvh] left-0 right-0 z-100 pointer-events-none">
         <%= render 'shared/flash_messages' %>
-        <%= yield %>
+      </div>
+
+      <%= yield %>
     </div>
     <div id="menu">
       <%= render 'layouts/menu' %>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,5 +1,31 @@
 <% flash.each do |message_type, message| %>
-  <div class="<%= flash_background_color(message_type) %> px-4 py-2 rounded-md">
-    <%= message %>
+  <div class="flex <%= flash_background_color(message_type) %> px-4 py-2 rounded-md pointer-events-auto">
+    <div class="flex-auto">
+      <%= message %>
+    </div>
+
+    <div>
+      <button onclick="this.closest('.pointer-events-auto').remove()" class="ml-4 hover:opacity-70 transition-opacity">
+        <span class="icon-[lucide--x] w-4 h-4"></span>
+      </button>
+    </div>
   </div>
 <% end %>
+
+<script>
+  (function() {
+    // 表示されたすべてのメッセージを取得
+    const messages = document.querySelectorAll("#flash_messages > div");
+    messages.forEach(msg => {
+      // 3秒後にアニメーションを開始し、その後削除
+      setTimeout(() => {
+        if (msg) {
+          msg.style.transition = "all 0.5s";
+          msg.style.opacity = "0";
+          msg.style.transform = "translateY(-10px)";
+          setTimeout(() => msg.remove(), 500);
+        }
+      }, 3000);
+    });
+  })();
+</script>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,5 +1,5 @@
 <div class="h-full flex justify-center items-center">
-  <%= image_tag('/tsumugi-logo-vertical.png', class: "max-h-[70svh]") %>
+  <%= image_tag('/tsumugi-logo-vertical.png', class: "max-h-3/4") %>
 </div>
 <div>
   <%= render 'layouts/footer' %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,3 +15,10 @@ ja:
       default: "%Y/%m/%d(%a)"
       long: "%Y年%m月%d日(%a)"
       short: "%m/%d"
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"
+      long: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      short: "%y/%m/%d %H:%M"
+      datetime: "%Y.%m.%d %H時%M分"
+      only_time: "%H:%M"


### PR DESCRIPTION
## 概要
`diaries/_diary`パーシャルのデザインを整える

## 関連issue
#108 

## やったこと
 - コピーライト部分のレイアウトの調整
 - 日記1件当たりの表示レイアウトを変更、モバイル端末での表示に最適化
 - ロゴの表示サイズを調整
 - 日記一覧からもリアクションを追加・除去できるよう変更
 - リアクションを表示、追加するための部分のデザイン調整
 - フラッシュメッセージの表示設定
 - 日記の絞り込み結果ページのデザインを調整

## やらないこと
 - カレンダー表示画面のデザインを整える
 - 日記詳細表示ページのデザインを整える

## テスト／完了確認
 - [x] デザインが崩れず、きちんと表示されていることを確認
 - [x] リアクションの追加と取り消しがきちんとできることを確認
 - [x] フラッシュメッセージの表示が正常であることを確認