### PR TITLE
Feature/#107 カレンダー表示画面のデザインを整える

### DIFF
--- a/app/views/diaries/date_index.html.erb
+++ b/app/views/diaries/date_index.html.erb
@@ -1,4 +1,4 @@
-<div id="date_index" class="min-h-screen bg-lime-50 pb-20">
+<div id="date_index" class="min-h-screen bg-lime-100 pb-20">
   <div class="px-4 py-6">
     <h1 class="text-2xl font-bold text-amber-900 text-center mb-6">
       <%= l(@date.to_date, format: :long) %>の日記

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -1,5 +1,4 @@
 <div id="diary_index" class="text-center">
-  <h1 class="text-3xl font-bold m-6">日記一覧</h1>
 
   <div id="diary_calendar" class="mx-4 my-8">
     <div class="text-center">

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -1,17 +1,12 @@
-<div id="diary_index" class="text-center">
-
-  <div id="diary_calendar" class="mx-4 my-8">
-    <div class="text-center">
+<div id="diary_index" class="bg-[#FFF9E5] min-h-screen pb-8">
+  <div class="max-w-4xl mx-auto">
+    <div id="diary_calendar" class="w-full">
       <%= month_calendar(attribute: :date, events: @diaries) do |date, diary| %>
-        <%= link_to date.day, date_index_diaries_path(date: date) %>
-
+        <%# _month_calendar.html.erbで日付がレンダリングされるため、ここでは絵文字のみを処理します %>
         <% diary.each do |d| %>
-          <div>
-            <%= link_to d.emoji.character, diary_path(d.id), data: { turbo: false } %>
-          </div>
+          <%= link_to d.emoji.character, diary_path(d.id), data: { turbo: false }, class: "text-2xl hover:scale-110 transition-transform" %>
         <% end %>
       <% end %>
     </div>
   </div>
-
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<div class="grid grid-cols-3 gap-2 items-center p-4 bg-lime-300">
+<div class="grid grid-cols-3 gap-2 items-center p-4 bg-lime-300 border-b border-lime-500">
   <div class="text-left col-span-2">
     <%=link_to image_tag('/tsumugi-logo.png', class: "max-w-4/5 md:w-1/2 lg:w-1/3 object-contain"), root_path %>
   </div>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,53 +1,83 @@
-<div class="simple-calendar">
-  <div class="calendar-heading">
-    <nav>
-      <div class="flex justify-center">
-        <div class="px-2">
-          <%= link_to t('simple_calendar.lastYear', default: 'LastYear'), url_for(params.permit(:start_date).to_h.merge(start_date: start_date.beginning_of_month - 1.year)) %>
-        </div>
-        <div class="px-2">
-          <span class="calendar-title"><%= start_date.year %> <%= t('date.year') %></span>
-        </div>
-        <div class="px-2">
-          <%= link_to t('simple_calendar.following', default: 'Following'), url_for(params.permit(:start_date).to_h.merge(start_date: start_date.beginning_of_month + 1.year)) %>
-        </div>
+<div class="simple-calendar bg-[#FFF9E5] min-h-screen py-8 px-2 sm:px-4 font-sans text-[#5D2E17]">
+  <!-- Redesigned header to match the image with circular navigation buttons and added year navigation -->
+  <div class="max-w-md mx-auto mb-4">
+    <div class="flex items-center justify-between">
+      <!-- Year & Month Previous Buttons -->
+      <div class="flex gap-2">
+        <%= link_to url_for(params.permit(:start_date).to_h.merge(start_date: start_date.beginning_of_year - 1.year)),
+            class: "w-12 h-12 flex items-center justify-center rounded-full bg-white border border-amber-200 shadow-sm text-amber-600 hover:bg-amber-50 transition-all active:scale-95",
+            title: "Previous Year" do %>
+          <span class="icon-[lucide--chevrons-left] text-xl"></span>
+        <% end %>
+        <%= link_to url_for(params.permit(:start_date).to_h.merge(start_date: start_date.beginning_of_month - 1.month)),
+            class: "w-12 h-12 flex items-center justify-center rounded-full bg-white border border-amber-200 shadow-sm text-amber-600 hover:bg-amber-50 transition-all active:scale-95",
+            title: "Previous Month" do %>
+          <span class="icon-[lucide--chevron-left] text-xl"></span>
+        <% end %>
       </div>
-      <div class="flex justify-center">
-        <div class="px-2">
-          <%= link_to t('simple_calendar.previous', default: 'Previous'), url_for(params.permit(:start_date).to_h.merge(start_date: start_date.beginning_of_month - 1.month)) %>
-        </div>
-        <div class="px-2">
-          <time datetime="<%= start_date.strftime('%Y-%m') %>" class="calendar-title"><%= t('date.month_names')[start_date.month] %></time>
-        </div>
-        <div class="px-2">
-          <%= link_to t('simple_calendar.next', default: 'Next'), url_for(params.permit(:start_date).to_h.merge(start_date: start_date.beginning_of_month + 1.month)) %>
-        </div>
+      <!-- Centered Month and Year -->
+      <h2 class="text-2xl sm:text-3xl font-black tracking-tight text-[#5D2E17]">
+        <%= t('date.month_names')[start_date.month] %> <%= start_date.year %>
+      </h2>
+      <!-- Month & Year Next Buttons -->
+      <div class="flex gap-2">
+        <%= link_to url_for(params.permit(:start_date).to_h.merge(start_date: start_date.beginning_of_month + 1.month)),
+            class: "w-12 h-12 flex items-center justify-center rounded-full bg-white border border-amber-200 shadow-sm text-amber-600 hover:bg-amber-50 transition-all active:scale-95",
+            title: "Next Month" do %>
+          <span class="icon-[lucide--chevron-right] text-xl"></span>
+        <% end %>
+        <%= link_to url_for(params.permit(:start_date).to_h.merge(start_date: start_date.beginning_of_year + 1.year)),
+            class: "w-12 h-12 flex items-center justify-center rounded-full bg-white border border-amber-200 shadow-sm text-amber-600 hover:bg-amber-50 transition-all active:scale-95",
+            title: "Next Year" do %>
+          <span class="icon-[lucide--chevrons-right] text-xl"></span>
+        <% end %>
       </div>
-      <div>
-        <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
-      </div>
-    </nav>
+    </div>
+
+    <!-- Today Button centered below -->
+    <div class="flex justify-center mt-4">
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view,
+          class: "text-sm font-bold text-amber-700 bg-amber-200/50 hover:bg-amber-200 px-3 py-2 rounded-full transition-colors" %>
+    </div>
   </div>
 
-  <table class="table table-striped">
-    <thead>
-      <tr>
-        <% date_range.slice(0, 7).each do |day| %>
-          <th><p class="text-center"><%= t('date.abbr_day_names')[day.wday] %></p></th>
-        <% end %>
-      </tr>
-    </thead>
-
-    <tbody>
-      <% date_range.each_slice(7) do |week| %>
-        <tr>
-          <% week.each do |day| %>
-            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
-              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
-            <% end %>
-          <% end %>
-        </tr>
+  <div class="max-w-full mx-auto bg-[#FEF3C7] rounded-3xl sm:rounded-3xl py-6 px-1 shadow-md border border-amber-200/50">
+    <div class="grid grid-cols-7 mb-4">
+      <% date_range.slice(0, 7).each do |day| %>
+        <div class="text-center">
+          <span class="text-md sm:text-md font-black text-[#A07B4F] uppercase tracking-wider">
+            <%= t('date.abbr_day_names')[day.wday] %>
+          </span>
+        </div>
       <% end %>
-    </tbody>
-  </table>
+    </div>
+    <div class="grid grid-cols-7 gap-x-1 sm:gap-x-0">
+      <% date_range.each do |day| %>
+        <%= content_tag :div, class: "relative group transition-all" do %>
+          <!-- Increased cell size on mobile and ensured fixed height with hidden scrollbars -->
+          <div class="aspect-[3/4.5] sm:aspect-[3/4.5] min-h-[80px] sm:min-h-[100px] flex flex-col items-stretch transition-all overflow-hidden
+            <%= day.month == start_date.month ? 'bg-[#F7FEE7]' : 'bg-lime-50/30 opacity-40' %>
+            border border-lime-200 cursor-pointer"
+          >
+            <!-- Date link positioned at the top-center of the cell -->
+            <div class="text-center pt-1 pb-1 relative inline-flex items-center justify-center">
+              <% if day == Date.today %>
+                <div class="absolute w-6 h-6 bg-rose-200/80 rounded-full blur-xs"></div>
+              <% end %>
+              <%= link_to day.day, date_index_diaries_path(date: day), class: "text-base font-bold transition-colors text-amber-800 hover:text-rose-600 #{day == Date.today ? 'relative': ''}" %>
+            </div>
+            <!-- Scrollable container with no-scrollbar class to hide ugly browser scrollbars -->
+            <div class="flex-grow overflow-y-auto no-scrollbar py-1">
+              <div class="flex flex-wrap items-center justify-center gap-1 sm:gap-1.5 min-h-full">
+                <!-- Centered emoji container with stable positioning -->
+                <div class="text-xl sm:text-4xl leading-none flex flex-wrap justify-center gap-1">
+                  <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
## 概要
カレンダー表示画面のデザインを整える

## 関連issue
#107 

## やったこと
 - `simple_calendar/_month_calendar`を編集
 - `diaries/index`を編集
 - ヘッダー部に境界線を引いた

## やらないこと
 - 

## テスト／完了確認
 - [x] カレンダー表示画面の表示がモバイル端末に最適化されていることを確認