### PR TITLE
Feature/#109 日記（記録）一覧表示画面のデザインを整える

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,9 @@
 
 ## 使用する技術スタック
  - バックエンド：Ruby on Rails
- - フロントエンド：React + TypeScript
  - データベース：PostgreSQL、Supabase（ユーザー認証）
- - デプロイ先：DBはNeon、APはfly.io
- - 使用予定のライブラリ（Gem）：bcrypt、gemoji、simple_calendar、Action Mailer、ransack、act_as_taggrable_on、kaminari、rubocop、Tailwind CSS
+ - デプロイ先：DBはNeon、APはkoyeb
+ - 使用予定のライブラリ（Gem）：simple_calendar、Action Mailer、ransack、act_as_taggrable_on、kaminari、rubocop、Tailwind CSS
 
 
 ## 画面遷移図
@@ -138,4 +137,4 @@
 ## ER図
  - https://www.mermaidchart.com/app/projects/8ef929a7-6ce2-47cc-8b6d-dabfd595e0e1/diagrams/ecf9d67c-e800-4b28-aa41-99b6c51f2afa/share/invite/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkb2N1bWVudElEIjoiZWNmOWQ2N2MtZTgwMC00YjI4LWFhNDEtOTliNmM1MWYyYWZhIiwiYWNjZXNzIjoiVmlldyIsImlhdCI6MTc2Mzc5NzkxMn0.PmJv0CZFbV6UB6tsgOEIIEtweJsKH6pgy6HSPZCAHnU
 
-[![おもいでつむぎ - ER図](https://i.gyazo.com/fe80f8394f34f8b4b63e93396fbb95c2.png)](https://gyazo.com/fe80f8394f34f8b4b63e93396fbb95c2)
+[![おもいでつむぎ - ER図](https://i.gyazo.com/2c1e38d569e1a47b55ead42b250a5a79.png)](https://gyazo.com/2c1e38d569e1a47b55ead42b250a5a79)

--- a/app/views/diaries/date_index.html.erb
+++ b/app/views/diaries/date_index.html.erb
@@ -1,4 +1,4 @@
-<div id="date_index" class="min-h-screen bg-lime-100 pb-20">
+<div id="date_index" class="min-h-screen bg-lime-50 pb-20">
   <div class="px-4 py-6">
     <h1 class="text-2xl font-bold text-amber-900 text-center mb-6">
       <%= l(@date.to_date, format: :long) %>の日記

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -1,4 +1,4 @@
-<div id="diary_index" class="bg-[#FFF9E5] min-h-screen pb-8">
+<div id="diary_index" class="bg-amber-50 min-h-screen">
   <div class="max-w-4xl mx-auto">
     <div id="diary_calendar" class="w-full">
       <%= month_calendar(attribute: :date, events: @diaries) do |date, diary| %>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,4 +1,4 @@
-<div class="simple-calendar bg-[#FFF9E5] min-h-screen py-8 px-2 sm:px-4 font-sans text-[#5D2E17]">
+<div class="simple-calendar bg-amber-50 min-h-screen pt-8 px-2 font-sans text-[#5D2E17]">
   <!-- Redesigned header to match the image with circular navigation buttons and added year navigation -->
   <div class="max-w-md mx-auto mb-4">
     <div class="flex items-center justify-between">

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,6 +1,5 @@
-<div class="simple-calendar bg-amber-50 min-h-screen pt-8 px-2 font-sans text-[#5D2E17]">
-  <!-- Redesigned header to match the image with circular navigation buttons and added year navigation -->
-  <div class="max-w-md mx-auto mb-4">
+<div class="simple-calendar bg-amber-50 min-h-screen pt-8 font-sans text-[#5D2E17]">
+  <div class="max-w-md mx-auto mb-4 px-4">
     <div class="flex items-center justify-between">
       <!-- Year & Month Previous Buttons -->
       <div class="flex gap-2">
@@ -16,8 +15,8 @@
         <% end %>
       </div>
       <!-- Centered Month and Year -->
-      <h2 class="text-2xl sm:text-3xl font-black tracking-tight text-[#5D2E17]">
-        <%= t('date.month_names')[start_date.month] %> <%= start_date.year %>
+      <h2 class="text-2xl sm:text-3xl font-black tracking-tight text-amber-900">
+        <%= start_date.year %>年 <%= t('date.month_names')[start_date.month] %>
       </h2>
       <!-- Month & Year Next Buttons -->
       <div class="flex gap-2">
@@ -41,22 +40,22 @@
     </div>
   </div>
 
-  <div class="max-w-full mx-auto bg-[#FEF3C7] rounded-3xl sm:rounded-3xl py-6 px-1 shadow-md border border-amber-200/50">
+  <div class="max-w-full mx-auto bg-amber-100 rounded-3xl sm:rounded-3xl py-6 px-1 shadow-md border border-amber-200/50">
     <div class="grid grid-cols-7 mb-4">
       <% date_range.slice(0, 7).each do |day| %>
         <div class="text-center">
-          <span class="text-md sm:text-md font-black text-[#A07B4F] uppercase tracking-wider">
+          <span class="text-md sm:text-md font-black text-amber-800 uppercase tracking-wider">
             <%= t('date.abbr_day_names')[day.wday] %>
           </span>
         </div>
       <% end %>
     </div>
-    <div class="grid grid-cols-7 gap-x-1 sm:gap-x-0">
+    <div class="grid grid-cols-7 gap-x-1">
       <% date_range.each do |day| %>
         <%= content_tag :div, class: "relative group transition-all" do %>
           <!-- Increased cell size on mobile and ensured fixed height with hidden scrollbars -->
-          <div class="aspect-[3/4.5] sm:aspect-[3/4.5] min-h-[80px] sm:min-h-[100px] flex flex-col items-stretch transition-all overflow-hidden
-            <%= day.month == start_date.month ? 'bg-[#F7FEE7]' : 'bg-lime-50/30 opacity-40' %>
+          <div class="aspect-[3/4.5] min-h-[80px] flex flex-col items-stretch transition-all overflow-hidden
+            <%= day.month == start_date.month ? 'bg-amber-50' : 'bg-lime-50/40 opacity-40' %>
             border border-lime-200 cursor-pointer"
           >
             <!-- Date link positioned at the top-center of the cell -->
@@ -68,9 +67,9 @@
             </div>
             <!-- Scrollable container with no-scrollbar class to hide ugly browser scrollbars -->
             <div class="flex-grow overflow-y-auto no-scrollbar py-1">
-              <div class="flex flex-wrap items-center justify-center gap-1 sm:gap-1.5 min-h-full">
+              <div class="flex flex-wrap items-center justify-center gap-1 min-h-full">
                 <!-- Centered emoji container with stable positioning -->
-                <div class="text-xl sm:text-4xl leading-none flex flex-wrap justify-center gap-1">
+                <div class="text-xl leading-none flex flex-wrap justify-center gap-1">
                   <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
                 </div>
               </div>


### PR DESCRIPTION
## 概要
日記（記録）一覧表示画面のデザインを整える。
既にある程度デザインを整えていたため、微調整に留めた。

## 関連issue
#109

## やったこと
 - 背景色や文字色、パディングの調整
	 - `diaries/index.html.erb`
	 - `simple_calendar/_month_calendar.html.erb`
	 - `diaries/date_index.html.erb`
 - `README`を修正

## やらないこと
 - 

## テスト／完了確認
 - [x] 日付ごとの日記一覧表示画面のデザインがモバイル端末に最適化されていることを確認
 - [x] 日記の絞り込み結果の一覧表示画面のデザインがモバイル端末に最適化されていることを確認

## 備考
 - `README`の修正点
	 - ER図を更新
	 - 使用技術のフロントエンドの部分を削除
		 - ひとまずビューをERBファイルのみで構成し、Reactへの移行はいずれとすることに決定