### PR TITLE
Feature/#111 1日分の日記（記録）一覧表示画面のデザインを整える

### DIFF
--- a/app/views/diaries/date_index.html.erb
+++ b/app/views/diaries/date_index.html.erb
@@ -1,4 +1,4 @@
-<div id="date_index" class="h-full bg-lime-50 pb-20">
+<div id="date_index" class="min-h-full bg-lime-50 pb-20">
   <div class="px-4 py-6">
     <h1 class="text-2xl font-bold text-amber-900 text-center mb-6">
       <%= l(@date.to_date, format: :long) %>の日記

--- a/app/views/layouts/_menu.html.erb
+++ b/app/views/layouts/_menu.html.erb
@@ -8,7 +8,7 @@
 
   <div id="go_to_home" class="flex flex-col items-center justify-center">
     <%= link_to diaries_path, data: { turbo: false }, class: "flex flex-col items-center gap-1 group" do %>
-      <span class="icon-[lucide--home] text-2xl text-amber-500 transition-transform group-active:scale-95"></span>
+      <span class="icon-[lucide--calendar] text-2xl text-amber-500 transition-transform group-active:scale-95"></span>
       <span class="text-[10px] font-bold text-amber-800">ホーム</span>
     <% end %>
   </div>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -4,12 +4,12 @@
       <!-- Year & Month Previous Buttons -->
       <div class="flex gap-2">
         <%= link_to url_for(params.permit(:start_date).to_h.merge(start_date: start_date.beginning_of_year - 1.year)),
-            class: "w-12 h-12 flex items-center justify-center rounded-full bg-white border border-amber-200 shadow-sm text-amber-600 hover:bg-amber-50 transition-all active:scale-95",
+            class: "w-10 h-10 flex items-center justify-center rounded-full bg-white border border-amber-200 shadow-sm text-amber-600 hover:bg-amber-50 transition-all active:scale-95",
             title: "Previous Year" do %>
           <span class="icon-[lucide--chevrons-left] text-xl"></span>
         <% end %>
         <%= link_to url_for(params.permit(:start_date).to_h.merge(start_date: start_date.beginning_of_month - 1.month)),
-            class: "w-12 h-12 flex items-center justify-center rounded-full bg-white border border-amber-200 shadow-sm text-amber-600 hover:bg-amber-50 transition-all active:scale-95",
+            class: "w-10 h-10 flex items-center justify-center rounded-full bg-white border border-amber-200 shadow-sm text-amber-600 hover:bg-amber-50 transition-all active:scale-95",
             title: "Previous Month" do %>
           <span class="icon-[lucide--chevron-left] text-xl"></span>
         <% end %>
@@ -21,12 +21,12 @@
       <!-- Month & Year Next Buttons -->
       <div class="flex gap-2">
         <%= link_to url_for(params.permit(:start_date).to_h.merge(start_date: start_date.beginning_of_month + 1.month)),
-            class: "w-12 h-12 flex items-center justify-center rounded-full bg-white border border-amber-200 shadow-sm text-amber-600 hover:bg-amber-50 transition-all active:scale-95",
+            class: "w-10 h-10 flex items-center justify-center rounded-full bg-white border border-amber-200 shadow-sm text-amber-600 hover:bg-amber-50 transition-all active:scale-95",
             title: "Next Month" do %>
           <span class="icon-[lucide--chevron-right] text-xl"></span>
         <% end %>
         <%= link_to url_for(params.permit(:start_date).to_h.merge(start_date: start_date.beginning_of_year + 1.year)),
-            class: "w-12 h-12 flex items-center justify-center rounded-full bg-white border border-amber-200 shadow-sm text-amber-600 hover:bg-amber-50 transition-all active:scale-95",
+            class: "w-10 h-10 flex items-center justify-center rounded-full bg-white border border-amber-200 shadow-sm text-amber-600 hover:bg-amber-50 transition-all active:scale-95",
             title: "Next Year" do %>
           <span class="icon-[lucide--chevrons-right] text-xl"></span>
         <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,8 +3,6 @@ ja:
     previous: "<<"
     next: ">>"
     today: "今日"
-    lastYear: "<"
-    following: ">"
   date:
     year: "年"
     abbr_day_names: [日, 月, 火, 水, 木, 金, 土]
@@ -88,6 +86,6 @@ ja:
     select:
       prompt: 選択してください
     submit:
-      create: 登録する
+      create: 投稿する
       submit: 保存する
       update: 更新する


### PR DESCRIPTION
## 概要
1日分の日記（記録）一覧表示画面のデザインを整える

## 関連issue
#111 

## やったこと
 - おおよそのデザインは出来上がっていたため、表示の調整を実施
 - メニュー部のホームメニューのアイコンを変更
 - カレンダー表示画面で年や月を移動するためのボタンを少し縮小

## やらないこと
 - 

## テスト／完了確認
 - [x] 1日分の日記（記録）一覧表示画面のデザインがモバイル端末に最適化されていることを確認