### PR TITLE
Feature/#112 日記編集画面のデザインを整える

### DIFF
--- a/app/views/diaries/date_index.html.erb
+++ b/app/views/diaries/date_index.html.erb
@@ -10,16 +10,14 @@
       </div>
     <% else %>
       <div class="flex flex-col items-center justify-center py-12">
-        <p class="text-muted-foreground text-center">日記はありません。</p>
+        <p class="text-muted-foreground text-center"><%= t('helpers.message.no_diary_on_day') %></p>
       </div>
     <% end %>
 
     <div class="mt-8 text-center">
-      <%= link_to diaries_path,
-          class: "inline-flex items-center justify-center px-6 py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:opacity-90 transition-opacity",
-          data: { turbo: false } do %>
-        カレンダーに戻る
-      <% end %>
+      <%= link_to t('helpers.link.back_to_calendar'), diaries_path,
+            class: "inline-flex items-center justify-center px-6 py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:opacity-90 transition-opacity",
+            data: { turbo: false } %>
     </div>
   </div>
 </div>

--- a/app/views/diaries/date_index.html.erb
+++ b/app/views/diaries/date_index.html.erb
@@ -1,11 +1,11 @@
 <div id="date_index" class="min-h-full bg-lime-50 pb-20">
-  <div class="px-4 py-6">
-    <h1 class="text-2xl font-bold text-amber-900 text-center mb-6">
+  <div class="px-4 py-4">
+    <h1 class="text-2xl font-bold text-amber-900 text-center mb-4">
       <%= l(@date.to_date, format: :long) %>の日記
     </h1>
 
     <% if @diaries.any? %>
-      <div class="flex flex-col gap-4">
+      <div class="flex flex-col gap-6">
         <%= render @diaries %>
       </div>
     <% else %>

--- a/app/views/diaries/edit.html.erb
+++ b/app/views/diaries/edit.html.erb
@@ -12,7 +12,7 @@
         <div class="mb-6">
           <div class="flex items-center mb-2">
             <span class="icon-[formkit--date] text-xl text-amber-600 mr-2"></span>
-            <%= f.label :date, "日付", class: "font-semibold text-amber-800 text-lg" %>
+            <%= f.label :date, t('activerecord.attributes.diary.date'), class: "font-semibold text-amber-800 text-lg" %>
           </div>
           <%= f.date_field :date, class: "w-full p-3 border border-amber-400 rounded-lg bg-white text-lime-800 shadow-sm" %>
         </div>
@@ -20,7 +20,7 @@
         <div class="mb-6">
           <div class="flex items-center mb-2">
             <span class="icon-[lucide--smile-plus] text-xl text-amber-600 mr-2"></span>
-            <%= f.label :emoji_id, "絵文字", class: "font-semibold text-amber-800 text-lg" %>
+            <%= f.label :emoji_id, t('activerecord.attributes.diary.emoji'), class: "font-semibold text-amber-800 text-lg" %>
           </div>
           <div class="relative">
             <%= f.collection_select :emoji_id, @emojis, :id, :character, { include_blank: "選択してください" }, { class: "w-full p-3 border border-amber-400 rounded-lg bg-white text-lime-800 text-md shadow-sm appearance-none cursor-pointer" } %>
@@ -42,7 +42,7 @@
             <span class="icon-[mdi--lead-pencil] text-xl text-amber-600 mr-2"></span>
             <%= f.label :body, "今日は何があった？", class: "font-semibold text-amber-800 text-lg" %>
           </div>
-          <%= f.text_area :body, class: "w-full p-3 border border-amber-400 rounded-lg h-28 resize-y bg-white text-lime-800 shadow-sm", placeholder: "今日あったことを書いてみよう！" %>
+          <%= f.text_area :body, class: "w-full p-3 border border-amber-400 rounded-lg h-28 resize-y bg-white text-lime-800 shadow-sm", placeholder: "今日はその子に何があった？" %>
         </div>
 
         <!-- Submit Button -->

--- a/app/views/diaries/edit.html.erb
+++ b/app/views/diaries/edit.html.erb
@@ -1,52 +1,59 @@
-<div id="edit_diary" class="text-center">
-  <h1 class="text-3xl font-bold m-6">日記を編集</h1>
+<div class="min-h-full bg-lime-50 flex flex-col items-center py-6 px-4 sm:px-6 lg:px-8">
+  <!-- Container -->
+  <div class="w-full max-w-md p-2 space-y-4">
+    <!-- Header Section -->
+    <h1 class="text-3xl font-extrabold text-lime-800 text-center mb-6">日記を編集</h1>
 
-  <div id="diary_edit_form">
-    <%= form_with(model: @diary, url: diary_path(diary_id: @diary.id), data: { turbo: false }, local: true) do |f| %>
-    <div class="my-4">
-      <div>
-        <%= f.label :date, "日付", class: "font-bold" %>
-      </div>
-      <div>
-        <%= f.date_field :date, class: "border border-default-medium" %>
-      </div>
-    </div>
-    <div class="my-4">
-      <div>
-        <%= f.label :child_ids, "どの子？", class: "font-bold" %>
-      </div>
-      <div>
-        <%= f.select :child_ids, Diary.child_combination_options(current_user.family),
-              include_blank: "選択してください",
-              name: "diary[child_ids][]",
-              class: "border border-default-medium" %>
-      </div>
-    </div>
-    <div class="my-4">
-        <%= f.label :emoji_id, "絵文字", class: "font-bold" %>
-      </div>
-      <div>
-        <%= f.select :emoji_id,
-            options_from_collection_for_select(@emojis, :id, :character, f.object.emoji_id), 
-            { include_blank: "選択してください" },
-            { class: "border border-default-medium" } %>
-      </div>
-    </div>
-    <div class="my-4">
-      <div>
-        <%= f.label :body, "本文", class: "font-bold" %>
-      </div>
-      <div>
-        <%= f.text_area :body, class: "border border-default-medium" %>
-      </div>
-    </div>
-    <div class="my-4">
-      <%= f.submit "更新する", class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2.5" %>
-    </div>
-    <% end %>
-  </div>
+    <!-- Form Card -->
+    <div class="bg-amber-50 rounded-2xl shadow-md border-2 border-amber-100 p-6 sm:p-8 space-y-8">
+      <%= form_with(model: @diary, method: :patch, data: { turbo: false }, local: true) do |f| %>
+        <%= render 'shared/error_messages', object: f.object %>
 
-  <div class="text-center">
-    <%= button_to "削除する", diary_path(@diary.id), method: :delete, data: { turbo_confirm: '本当にこの日記を削除しますか？' }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
+        <div class="mb-6">
+          <div class="flex items-center mb-2">
+            <span class="icon-[formkit--date] text-xl text-amber-600 mr-2"></span>
+            <%= f.label :date, "日付", class: "font-semibold text-amber-800 text-lg" %>
+          </div>
+          <%= f.date_field :date, class: "w-full p-3 border border-amber-400 rounded-lg bg-white text-lime-800 shadow-sm" %>
+        </div>
+
+        <div class="mb-6">
+          <div class="flex items-center mb-2">
+            <span class="icon-[lucide--smile-plus] text-xl text-amber-600 mr-2"></span>
+            <%= f.label :emoji_id, "絵文字", class: "font-semibold text-amber-800 text-lg" %>
+          </div>
+          <div class="relative">
+            <%= f.collection_select :emoji_id, @emojis, :id, :character, { include_blank: "選択してください" }, { class: "w-full p-3 border border-amber-400 rounded-lg bg-white text-lime-800 text-md shadow-sm appearance-none cursor-pointer" } %>
+          </div>
+        </div>
+
+        <div class="mb-6">
+          <div class="flex items-center mb-2">
+            <span class="icon-[hugeicons--child] text-xl text-amber-600 mr-2"></span>
+            <%= f.label :child_ids, "どの子？", class: "font-semibold text-amber-800 text-lg" %>
+          </div>
+          <div class="relative">
+            <%= f.select :child_ids, Diary.child_combination_options(current_user.family), { include_blank: "選択してください", selected: f.object.child_ids }, { name: "diary[child_ids][]", class: "w-full p-3 border border-amber-400 rounded-lg bg-white text-lime-800 text-md shadow-sm appearance-none cursor-pointer" } %>
+          </div>
+        </div>
+
+        <div class="mb-8">
+          <div class="flex items-center mb-2">
+            <span class="icon-[mdi--lead-pencil] text-xl text-amber-600 mr-2"></span>
+            <%= f.label :body, "今日は何があった？", class: "font-semibold text-amber-800 text-lg" %>
+          </div>
+          <%= f.text_area :body, class: "w-full p-3 border border-amber-400 rounded-lg h-28 resize-y bg-white text-lime-800 shadow-sm", placeholder: "今日あったことを書いてみよう！" %>
+        </div>
+
+        <!-- Submit Button -->
+        <div class="text-center">
+          <%= f.submit t('helpers.submit.diary.update'), class: "w-full bg-amber-500 hover:bg-amber-600 text-white font-bold py-2 px-6 rounded-full shadow-md transition duration-300 ease-in-out" %>
+        </div>
+      <% end %>
+
+      <div class="text-center">
+        <%= button_to t('helpers.submit.diary.destroy'), diary_path(@diary.id), method: :delete, data: { turbo_confirm: '本当にこの日記を削除しますか？' }, class: "w-full bg-rose-400 hover:bg-rose-500 text-white font-bold py-2 px-6 rounded-full shadow-md transition duration-300 ease-in-out" %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/diaries/edit.html.erb
+++ b/app/views/diaries/edit.html.erb
@@ -1,11 +1,11 @@
-<div class="min-h-full bg-lime-50 flex flex-col items-center py-6 px-4 sm:px-6 lg:px-8">
+<div class="min-h-full bg-lime-50 flex flex-col items-center py-3 px-4 sm:px-6 lg:px-8">
   <!-- Container -->
-  <div class="w-full max-w-md p-2 space-y-4">
+  <div class="w-full max-w-md p-2 space-y-2">
     <!-- Header Section -->
-    <h1 class="text-3xl font-extrabold text-lime-800 text-center mb-6">日記を編集</h1>
+    <h1 class="text-3xl font-extrabold text-lime-800 text-center mb-4">日記を編集</h1>
 
     <!-- Form Card -->
-    <div class="bg-amber-50 rounded-2xl shadow-md border-2 border-amber-100 p-6 sm:p-8 space-y-8">
+    <div class="bg-amber-50 rounded-2xl shadow-md border-2 border-amber-100 p-6 sm:p-8 space-y-4">
       <%= form_with(model: @diary, method: :patch, data: { turbo: false }, local: true) do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
 

--- a/app/views/diaries/filter.html.erb
+++ b/app/views/diaries/filter.html.erb
@@ -1,8 +1,8 @@
 <div id="filter_diaries" class="min-h-full bg-lime-50 pb-20">
-  <div class="px-4 py-6">
-    <h1 class="text-2xl font-bold text-amber-900 text-center mb-6">日記を絞り込む</h1>
+  <div class="px-4 py-4">
+    <h1 class="text-2xl font-bold text-amber-900 text-center mb-4">日記を絞り込む</h1>
 
-    <div class="flex flex-wrap justify-center gap-2 my-6">
+    <div class="flex flex-wrap justify-center gap-2 my-4">
       <% if @selected_children.present? || @selected_emoji.present? %>
         
         <% if @selected_children.present? %>
@@ -43,7 +43,7 @@
 
     <div class="diary-list">
       <% if @diaries.any? %>
-        <div class="flex flex-col gap-4">
+        <div class="flex flex-col gap-6">
           <%= render @diaries %>
         </div>
       <% else %>

--- a/app/views/diaries/filter.html.erb
+++ b/app/views/diaries/filter.html.erb
@@ -48,15 +48,13 @@
         </div>
       <% else %>
         <div class="flex flex-col items-center justify-center py-12">
-          <p class="text-muted-foreground text-center">該当する日記はありません。</p>
+          <p class="text-muted-foreground text-center"><%= t('helpers.message.no_diary_found') %></p>
         </div>
       <% end %>
       <div class="mt-8 text-center">
-        <%= link_to diaries_path,
+        <%= link_to t('helpers.link.back_to_calendar'), diaries_path,
             class: "inline-flex items-center justify-center px-6 py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:opacity-90 transition-opacity",
-            data: { turbo: false } do %>
-          カレンダーに戻る
-        <% end %>
+            data: { turbo: false } %>
       </div>
     </div>
   </div>

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -3,7 +3,7 @@
     <div id="diary_calendar" class="w-full">
       <%= month_calendar(attribute: :date, events: @diaries) do |date, diary| %>
         <% diary.each do |d| %>
-          <%= link_to d.emoji.character, diary_path(d.id), data: { turbo: false }, class: "text-xl lg:m-2 hover:scale-110 transition-transform" %>
+          <%= link_to d.emoji.character, diary_path(d.id), data: { turbo: false }, class: "text-2xl lg:m-2 hover:scale-110 transition-transform" %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -1,10 +1,9 @@
-<div id="diary_index" class="bg-amber-50 min-h-screen">
+<div id="diary_index" class="bg-amber-50 min-h-full">
   <div class="max-w-4xl mx-auto">
     <div id="diary_calendar" class="w-full">
       <%= month_calendar(attribute: :date, events: @diaries) do |date, diary| %>
-        <%# _month_calendar.html.erbで日付がレンダリングされるため、ここでは絵文字のみを処理します %>
         <% diary.each do |d| %>
-          <%= link_to d.emoji.character, diary_path(d.id), data: { turbo: false }, class: "text-2xl hover:scale-110 transition-transform" %>
+          <%= link_to d.emoji.character, diary_path(d.id), data: { turbo: false }, class: "text-xl lg:m-2 hover:scale-110 transition-transform" %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/diaries/new.html.erb
+++ b/app/views/diaries/new.html.erb
@@ -1,11 +1,11 @@
-<div class="min-h-full bg-lime-50 flex flex-col items-center py-6 px-4 sm:px-6 lg:px-8">
+<div class="min-h-full bg-lime-50 flex flex-col items-center py-3 px-4 sm:px-6 lg:px-8">
   <!-- Container -->
   <div class="w-full max-w-md p-2 space-y-4">
     <!-- Header Section -->
-    <h1 class="text-3xl font-extrabold text-lime-800 text-center mb-6">日記を投稿</h1>
+    <h1 class="text-3xl font-extrabold text-lime-800 text-center mb-4">日記を投稿</h1>
 
     <!-- Form Card -->
-    <div class="bg-amber-50 rounded-2xl shadow-md border-2 border-amber-100 p-6 sm:p-8 space-y-8">
+    <div class="bg-amber-50 rounded-2xl shadow-md border-2 border-amber-100 p-6 sm:p-8 space-y-4">
       <%= form_with(model: @diary, method: :post, data: { turbo: false }, local: true) do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
 

--- a/app/views/diaries/new.html.erb
+++ b/app/views/diaries/new.html.erb
@@ -12,7 +12,7 @@
         <div class="mb-6">
           <div class="flex items-center mb-2">
             <span class="icon-[formkit--date] text-xl text-amber-600 mr-2"></span>
-            <%= f.label :date, "日付", class: "font-semibold text-amber-800 text-lg" %>
+            <%= f.label :date, t('activerecord.attributes.diary.date'), class: "font-semibold text-amber-800 text-lg" %>
           </div>
           <%= f.date_field :date, class: "w-full p-3 border border-amber-400 rounded-lg bg-white text-lime-800 shadow-sm" %>
         </div>
@@ -20,7 +20,7 @@
         <div class="mb-6">
           <div class="flex items-center mb-2">
             <span class="icon-[lucide--smile-plus] text-xl text-amber-600 mr-2"></span>
-            <%= f.label :emoji_id, "絵文字", class: "font-semibold text-amber-800 text-lg" %>
+            <%= f.label :emoji_id, t('activerecord.attributes.diary.emoji'), class: "font-semibold text-amber-800 text-lg" %>
           </div>
           <div class="relative">
             <%= f.collection_select :emoji_id, @emojis, :id, :character, { include_blank: "選択してください" }, { class: "w-full p-3 border border-amber-400 rounded-lg bg-white text-lime-800 text-md shadow-sm appearance-none cursor-pointer" } %>
@@ -47,7 +47,7 @@
 
         <!-- Submit Button -->
         <div class="text-center">
-          <%= f.submit "投稿する", class: "w-full bg-amber-500 hover:bg-amber-600 text-white font-bold py-3 px-6 rounded-full shadow-md transition duration-300 ease-in-out" %>
+          <%= f.submit t('helpers.submit.diary.create'), class: "w-full bg-amber-500 hover:bg-amber-600 text-white font-bold py-3 px-6 rounded-full shadow-md transition duration-300 ease-in-out" %>
         </div>
       <% end %>
     </div>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,4 +1,4 @@
-<div class="simple-calendar bg-amber-50 min-h-screen py-2 font-sans text-[#5D2E17]">
+<div class="simple-calendar bg-amber-50 min-h-full py-2 font-sans text-[#5D2E17]">
   <div class="max-w-md mx-auto m-2 px-4">
     <div class="flex items-center justify-between">
       <!-- Year & Month Previous Buttons -->
@@ -15,7 +15,7 @@
         <% end %>
       </div>
       <!-- Centered Month and Year -->
-      <h2 class="text-2xl sm:text-3xl font-black tracking-tight text-amber-900">
+      <h2 class="text-3xl sm:text-3xl font-black tracking-tight text-amber-900">
         <%= start_date.year %>年 <%= t('date.month_names')[start_date.month] %>
       </h2>
       <!-- Month & Year Next Buttons -->
@@ -40,7 +40,7 @@
     </div>
   </div>
 
-  <div class="max-w-full mx-auto bg-amber-100 rounded-3xl sm:rounded-3xl py-6 px-1 shadow-md border border-amber-200/50">
+  <div class="max-w-full mx-2 bg-amber-100 rounded-3xl sm:rounded-3xl py-6 px-1 shadow-md border border-amber-200/50">
     <div class="grid grid-cols-7 mb-2">
       <% date_range.slice(0, 7).each do |day| %>
         <div class="text-center">
@@ -54,19 +54,19 @@
       <% date_range.each do |day| %>
         <%= content_tag :div, class: "relative group transition-all" do %>
           <!-- Increased cell size on mobile and ensured fixed height with hidden scrollbars -->
-          <div class="aspect-[3/4.5] min-h-[80px] flex flex-col items-stretch transition-all overflow-hidden
-            <%= day.month == start_date.month ? 'bg-amber-50' : 'bg-lime-50/40 opacity-40' %>
-            border border-lime-200 cursor-pointer"
+          <div class="aspect-[3/4] min-h-[65px] flex flex-col items-stretch transition-all overflow-hidden
+            <%= day.month == start_date.month ? 'bg-amber-50' : 'bg-lime-100/50 opacity-40' %>
+            border border-lime-400/50 cursor-pointer rounded-md lg:rounded-xl"
           >
             <!-- Date link positioned at the top-center of the cell -->
-            <div class="text-center pt-1 pb-1 relative inline-flex items-center justify-center">
+            <div class="text-center pt-1 relative inline-flex items-center justify-center">
               <% if day == Date.today %>
                 <div class="absolute w-6 h-6 bg-rose-200/80 rounded-full blur-xs"></div>
               <% end %>
               <%= link_to day.day, date_index_diaries_path(date: day), class: "text-base font-bold transition-colors text-amber-800 hover:text-rose-600 #{day == Date.today ? 'relative': ''}" %>
             </div>
             <!-- Scrollable container with no-scrollbar class to hide ugly browser scrollbars -->
-            <div class="flex-grow overflow-y-auto no-scrollbar py-1">
+            <div class="flex-grow overflow-y-auto no-scrollbar">
               <div class="flex flex-wrap items-center justify-center gap-1 min-h-full">
                 <!-- Centered emoji container with stable positioning -->
                 <div class="text-xl leading-none flex flex-wrap justify-center gap-1">

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,5 +1,5 @@
-<div class="simple-calendar bg-amber-50 min-h-screen pt-8 font-sans text-[#5D2E17]">
-  <div class="max-w-md mx-auto mb-4 px-4">
+<div class="simple-calendar bg-amber-50 min-h-screen py-2 font-sans text-[#5D2E17]">
+  <div class="max-w-md mx-auto m-2 px-4">
     <div class="flex items-center justify-between">
       <!-- Year & Month Previous Buttons -->
       <div class="flex gap-2">
@@ -34,14 +34,14 @@
     </div>
 
     <!-- Today Button centered below -->
-    <div class="flex justify-center mt-4">
+    <div class="flex justify-center mt-2">
       <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view,
           class: "text-sm font-bold text-amber-700 bg-amber-200/50 hover:bg-amber-200 px-3 py-2 rounded-full transition-colors" %>
     </div>
   </div>
 
   <div class="max-w-full mx-auto bg-amber-100 rounded-3xl sm:rounded-3xl py-6 px-1 shadow-md border border-amber-200/50">
-    <div class="grid grid-cols-7 mb-4">
+    <div class="grid grid-cols-7 mb-2">
       <% date_range.slice(0, 7).each do |day| %>
         <div class="text-center">
           <span class="text-md sm:text-md font-black text-amber-800 uppercase tracking-wider">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -86,6 +86,8 @@ ja:
     select:
       prompt: 選択してください
     submit:
-      create: 投稿する
-      submit: 保存する
-      update: 更新する
+      diary:
+        create: 投稿する
+        submit: 保存する
+        update: 更新する
+        destroy: 削除する

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -91,3 +91,8 @@ ja:
         submit: 保存する
         update: 更新する
         destroy: 削除する
+    message:
+      no_diary_found: 該当する日記はありません。
+      no_diary_on_day: この日の日記はありません。
+    link:
+      back_to_calendar: カレンダーに戻る


### PR DESCRIPTION
## 概要
日記編集画面のデザインを整える

## 関連issue
#112 

## やったこと
 - 日記編集画面のデザインを新規投稿ページをもとに整えた
 - フォームの文言をi18n化
 - リンクと「日記がありません」の表示をi18n化
 - 余白や表示の調整
	 - `diaries/date_index`
	 - `diaries/filter`
	 - `diaries/index`
	 - `simple_calendar/_month_calendar`

## やらないこと
 - 日記詳細表示ページのデザインを整える
 - ページのタイトル表示のi18n化

## テスト／完了確認
 - [x] 日記編集画面がモバイル端末に最適化されていることを確認
 - [x] 日記の更新が問題なくできることを確認
 - [x] i18n化した部分の表示が問題ないことを確認