### PR TITLE
Feature/#115 ログインページのデザインを整える

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,16 +1,6 @@
 class ApplicationController < ActionController::Base
   helper_method :current_user, :logged_in?
 
-  def require_login
-    # current_userを呼び出すだけで、認証プロセスが実行される
-    unless current_user
-      flash[:alert] = 'ログインが必要です。'
-      # ログアウト処理後にリダイレクト先が正しいか確認 (root_pathなど)
-      redirect_to auth_path
-      return false
-    end
-  end
-
   def current_user
     # セッションにIDがあれば、そのユーザーをDBから探す（結果を@current_userにキャッシュ）
     @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -1,5 +1,5 @@
 class DiariesController < ApplicationController
-  before_action :require_login
+  before_action :authenticate_user!
   before_action :set_diary, only: [:edit, :update, :destroy]
   before_action :check_family, only: [:index, :show, :new, :create, :edit, :update, :destroy]
   

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -2,7 +2,7 @@ class MypagesController < ApplicationController
   before_action :authenticate_user!
     
   def show
-    # require_loginが成功していれば、@current_userが利用可能
+    # authenticate_user!が成功していれば、@current_userが利用可能
     @user = current_user
     
     # Supabaseからプロフィールデータを取得するロジックを呼び出す
@@ -39,15 +39,11 @@ class MypagesController < ApplicationController
 
   # Supabaseからプロフィールを取得する（仮メソッド）
   def fetch_supabase_profile_data(supabase_uid)
-    # 実際にはここで、SupabaseのServer API Keyを使って、
-    # profilesテーブルから name や avatar_url などをフェッチする処理が入る
-    
-    # 例: データをフェッチするまで、メールアドレスとUIDを仮データとして返す
+    # データをフェッチするまで、メールアドレスとUIDを仮データとして返す
     {
       name: @user.email.split('@').first,
       email: @user.email,
       supabase_uid: supabase_uid
     }
   end
-
 end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,5 +1,5 @@
 class MypagesController < ApplicationController
-  before_action :require_login
+  before_action :authenticate_user!
     
   def show
     # require_loginが成功していれば、@current_userが利用可能
@@ -7,8 +7,6 @@ class MypagesController < ApplicationController
     
     # Supabaseからプロフィールデータを取得するロジックを呼び出す
     @profile_data = fetch_supabase_profile_data(@user.supabase_uid)
-    
-    # app/views/my_pages/show.html.erb がレンダリングされる
   end
 
   def edit

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,8 +1,19 @@
 class PasswordsController < ApplicationController
-  before_action :authenticate_user!
-
   # メールアドレス入力画面
   def new; end
+
+  # リセットメール送信リクエスト
+  def create
+    email = params[:email]
+    response = send_reset_email(email)
+
+    if response[:success]
+      redirect_to login_path, notice: "パスワード再設定用のメールを送信しました"
+    else
+      flash.now[:alert] = "エラー: #{response[:error]}"
+      render :new
+    end
+  end
 
   # パスワード変更画面
   def edit
@@ -12,27 +23,60 @@ class PasswordsController < ApplicationController
   def update
     new_password = params[:password]
     password_confirmation = params[:password_confirmation]
+    # 明示的に params から取る
+    access_token = params[:access_token].presence || cookies[:rails_access_token]
 
-    # 1. 簡易的なバリデーション
+    # バリデーション
     if new_password.blank? || new_password != password_confirmation
-      flash.now[:alert] = "パスワードが一致しないか、入力されていません。"
-      return render :edit
+      flash.now[:alert] = "パスワードが一致しないか、入力されていません"
+      return render :edit, status: :unprocessable_entity
     end
 
-    # 2. SupabaseのAPIを叩いてパスワードを更新
-    # ログイン時に保存したクッキー内のトークンを使用
-    access_token = cookies[:rails_access_token]
+    if access_token.blank?
+      flash.now[:alert] = "トークンが見つかりません。メールのリンクからやり直してください"
+      return render :edit, status: :unprocessable_entity
+    end
+
     response = update_supabase_password(access_token, new_password)
 
     if response[:success]
-      redirect_to root_path, notice: "パスワードを正常に更新しました。"
+      cookies.delete(:rails_access_token)
+      redirect_to login_path, notice: "パスワードを更新しました。新しいパスワードでログインしてください"
     else
-      flash.now[:alert] = "更新に失敗しました: #{response[:error]}"
-      render :edit
+      flash.now[:alert] = "エラー: #{response[:error]}"
+      render :edit, status: :unprocessable_entity
     end
   end
 
   private
+
+  def send_reset_email(email)
+    # Supabaseのパスワードリカバリ用エンドポイント
+    redirect_url = CGI.escape(edit_password_url)
+    url = URI("#{ENV['SUPABASE_URL']}/auth/v1/recover?redirect_to=#{redirect_url}")
+    
+    http = Net::HTTP.new(url.host, url.port)
+    http.use_ssl = true
+    
+    request = Net::HTTP::Post.new(url)
+    request["apikey"] = ENV['SUPABASE_SERVICE_ROLE_KEY']
+    request["Authorization"] = "Bearer #{ENV['SUPABASE_SERVICE_ROLE_KEY']}"
+    request["Content-Type"] = "application/json"
+    
+    request.body = { email: email }.to_json
+
+    response = http.request(request)
+    body = JSON.parse(response.body).with_indifferent_access
+
+    if response.code == "200" || response.code == "201"
+      { success: true }
+    else
+      { success: false, error: body[:msg] || body[:error_description] || "メール送信に失敗しました" }
+    end
+  rescue => e
+    logger.error "Supabase Recover Error: #{e.message}"
+    { success: false, error: "通信エラーが発生しました" }
+  end
 
   def update_supabase_password(token, new_password)
     url = URI("#{ENV['SUPABASE_URL']}/auth/v1/user")
@@ -53,10 +97,10 @@ class PasswordsController < ApplicationController
     if response.code == "200"
       { success: true }
     else
-      { success: false, error: body[:msg] || "パスワードの更新に失敗しました。" }
+      { success: false, error: body[:msg] || "パスワードの更新に失敗しました" }
     end
   rescue => e
     logger.error "Password Update Error: #{e.message}"
-    { success: false, error: "通信エラーが発生しました。" }
+    { success: false, error: "通信エラーが発生しました" }
   end
 end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,0 +1,62 @@
+class PasswordsController < ApplicationController
+  before_action :authenticate_user!
+
+  # メールアドレス入力画面
+  def new; end
+
+  # パスワード変更画面
+  def edit
+  end
+
+  # パスワード更新実行
+  def update
+    new_password = params[:password]
+    password_confirmation = params[:password_confirmation]
+
+    # 1. 簡易的なバリデーション
+    if new_password.blank? || new_password != password_confirmation
+      flash.now[:alert] = "パスワードが一致しないか、入力されていません。"
+      return render :edit
+    end
+
+    # 2. SupabaseのAPIを叩いてパスワードを更新
+    # ログイン時に保存したクッキー内のトークンを使用
+    access_token = cookies[:rails_access_token]
+    response = update_supabase_password(access_token, new_password)
+
+    if response[:success]
+      redirect_to root_path, notice: "パスワードを正常に更新しました。"
+    else
+      flash.now[:alert] = "更新に失敗しました: #{response[:error]}"
+      render :edit
+    end
+  end
+
+  private
+
+  def update_supabase_password(token, new_password)
+    url = URI("#{ENV['SUPABASE_URL']}/auth/v1/user")
+    
+    http = Net::HTTP.new(url.host, url.port)
+    http.use_ssl = true
+    
+    request = Net::HTTP::Put.new(url) # 更新なのでPUTメソッド
+    request["apikey"] = ENV['SUPABASE_SERVICE_ROLE_KEY']
+    request["Authorization"] = "Bearer #{token}" # ユーザーのトークンを渡す
+    request["Content-Type"] = "application/json"
+    
+    request.body = { password: new_password }.to_json
+    
+    response = http.request(request)
+    body = JSON.parse(response.body).with_indifferent_access
+    
+    if response.code == "200"
+      { success: true }
+    else
+      { success: false, error: body[:msg] || "パスワードの更新に失敗しました。" }
+    end
+  rescue => e
+    logger.error "Password Update Error: #{e.message}"
+    { success: false, error: "通信エラーが発生しました。" }
+  end
+end

--- a/app/views/auth/login.html.erb
+++ b/app/views/auth/login.html.erb
@@ -1,27 +1,33 @@
-<div class="flex-grow w-full flex bg-gray-100 p-6 justify-center items-start">
-  <div class="w-full max-w-md bg-white p-6 shadow-md rounded-lg space-y-4">
-    <h2 class="text-xl font-bold text-gray-800">ログイン</h2>
+<div class="min-h-full bg-lime-50 flex flex-col justify-center items-center py-4 px-4 sm:px-6 lg:px-8">
+  <h2 class="text-3xl font-extrabold text-lime-800 text-center mb-4">ログイン</h2>
 
-    <%= form_with(scope: :session, url: login_path, local: true, class: "space-y-4") do |f| %>
+  <div class="w-full max-w-sm bg-amber-100/60 rounded-2xl shadow-lg p-6 space-y-6 border border-amber-200">
+    <%= form_with(scope: :session, url: login_path, local: true, class: "space-y-6") do |f| %>
+      <%# エラー表示 %>
+      <%= render 'shared/error_messages', object: f.object %>
+
+      <%# メールアドレス %>
       <div>
-        <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.email_field :email, required: true, class: "w-full p-2 border border-gray-400 rounded-lg" %>
+        <%= f.label :email, t('activerecord.attributes.user.email'), class: "block text-base font-semibold text-amber-800 mb-2" %>
+        <%= f.email_field :email, required: true, class: "w-full p-3 border border-amber-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent transition duration-200 ease-in-out bg-white text-lime-800 shadow-sm", placeholder: "メールアドレスを入力してください" %>
       </div>
 
+      <%# パスワード %>
       <div>
-        <%= f.label :password, "パスワード", class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.password_field :password, required: true, class: "w-full p-2 border border-gray-400 rounded-lg" %>
+        <%= f.label :password, t('activerecord.attributes.user.password'), class: "block text-base font-semibold text-amber-800 mb-2" %>
+        <%= f.password_field :password, required: true, class: "w-full p-3 border border-amber-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent transition duration-200 ease-in-out bg-white text-lime-800 shadow-sm", placeholder: "パスワードを入力してください" %>
       </div>
 
       <div class="text-right">
-        <%= link_to "パスワードをお忘れですか？", "#", class: "text-xs text-blue-600 hover:underline" %>
+        <%= link_to "パスワードをお忘れですか？", "#", class: "text-sm text-lime-600 hover:text-lime-800 transition-colors duration-200" %>
       </div>
 
-      <%= f.submit "ログイン", class: "w-full bg-gray-800 hover:bg-gray-700 text-white font-semibold py-2 rounded-lg transition duration-200 cursor-pointer" %>
+      <%# ログインボタン %>
+      <%= f.submit t('helpers.submit.user.submit'), class: "w-full bg-lime-600 hover:bg-lime-700 text-white font-bold py-3 px-6 rounded-full shadow-md transition duration-300 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-opacity-50 tracking-wide" %>
     <% end %>
+  </div>
 
-    <div class="mt-4 text-center">
-      <%= link_to "→ 新規登録はこちら", signup_path, class: "text-sm text-gray-600 hover:text-gray-800" %>
-    </div>
+  <div class="my-6 text-center">
+    <%= link_to t('helpers.link.go_to_login'), signup_path, class: "text-base font-medium text-lime-600 hover:text-lime-800 transition-colors duration-200" %>
   </div>
 </div>

--- a/app/views/auth/login.html.erb
+++ b/app/views/auth/login.html.erb
@@ -1,7 +1,7 @@
 <div class="min-h-full bg-lime-50 flex flex-col justify-center items-center py-4 px-4 sm:px-6 lg:px-8">
   <h2 class="text-3xl font-extrabold text-lime-800 text-center mb-4">ログイン</h2>
 
-  <div class="w-full max-w-sm bg-amber-100/60 rounded-2xl shadow-lg p-6 space-y-6 border border-amber-200">
+  <div class="w-full max-w-sm bg-amber-100/60 rounded-2xl shadow-lg p-6 space-y-4 border border-amber-200">
     <%= form_with(scope: :session, url: login_path, local: true, class: "space-y-6") do |f| %>
       <%# エラー表示 %>
       <%= render 'shared/error_messages', object: f.object %>
@@ -19,11 +19,11 @@
       </div>
 
       <div class="text-right">
-        <%= link_to "パスワードをお忘れですか？", new_password_reset_path, class: "text-sm text-lime-600 hover:text-lime-800 transition-colors duration-200" %>
+        <%= link_to t('helpers.link.forget_password'), new_password_reset_path, class: "text-sm text-lime-600 hover:text-lime-800 transition-colors duration-200" %>
       </div>
 
       <%# ログインボタン %>
-      <%= f.submit t('helpers.submit.user.submit'), class: "w-full bg-lime-600 hover:bg-lime-700 text-white font-bold py-3 px-6 rounded-full shadow-md transition duration-300 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-opacity-50 tracking-wide" %>
+      <%= f.submit t('helpers.submit.user.submit'), class: "w-full bg-lime-600 hover:bg-lime-700 text-white font-bold py-3 px-6 rounded-full shadow-md transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-opacity-50 tracking-wide" %>
     <% end %>
   </div>
 

--- a/app/views/auth/login.html.erb
+++ b/app/views/auth/login.html.erb
@@ -19,7 +19,7 @@
       </div>
 
       <div class="text-right">
-        <%= link_to "パスワードをお忘れですか？", "#", class: "text-sm text-lime-600 hover:text-lime-800 transition-colors duration-200" %>
+        <%= link_to "パスワードをお忘れですか？", new_password_reset_path, class: "text-sm text-lime-600 hover:text-lime-800 transition-colors duration-200" %>
       </div>
 
       <%# ログインボタン %>

--- a/app/views/auth/login.html.erb
+++ b/app/views/auth/login.html.erb
@@ -28,6 +28,6 @@
   </div>
 
   <div class="my-6 text-center">
-    <%= link_to t('helpers.link.go_to_login'), signup_path, class: "text-base font-medium text-lime-600 hover:text-lime-800 transition-colors duration-200" %>
+    <%= link_to t('helpers.link.go_to_signup'), signup_path, class: "text-base font-medium text-lime-600 hover:text-lime-800 transition-colors duration-200" %>
   </div>
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<div class="grid grid-cols-3 gap-2 items-center p-4 bg-lime-300 border-b border-lime-500">
+<div class="grid grid-cols-3 gap-1 items-center py-4 px-4 sm:px-4 lg:px-6 bg-lime-300 border-b border-lime-500">
   <div class="text-left col-span-2">
     <%=link_to image_tag('/tsumugi-logo.png', class: "max-w-4/5 md:w-1/2 lg:w-1/3 object-contain"), root_path %>
   </div>
@@ -10,7 +10,7 @@
         <span class="text-[12px] font-bold text-lime-900">ログアウト</span>
       <% end %>
     <% else %>
-      <div class="flex justify-center gap-6">
+      <div class="flex justify-center gap-5">
         <div>
           <%= link_to signup_path, data: { turbo: :false }, class: "flex flex-col items-center gap-1 group" do %>
             <span class="icon-[lucide--user-plus] text-xl text-lime-700 transition-transform group-active:scale-95"></span>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,20 +7,20 @@
     <% if logged_in? %>
       <%= link_to logout_path, data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" }, class: "flex flex-col items-center gap-1 group" do %>
         <span class="icon-[lucide--log-out] text-xl text-lime-700 transition-transform group-active:scale-95"></span>
-        <span class="text-[12px] font-bold text-lime-900">ログアウト</span>
+        <span class="text-[12px] font-bold text-lime-900"><%= t('helpers.link.logout') %></span>
       <% end %>
     <% else %>
       <div class="flex justify-center gap-5">
         <div>
           <%= link_to signup_path, data: { turbo: :false }, class: "flex flex-col items-center gap-1 group" do %>
             <span class="icon-[lucide--user-plus] text-xl text-lime-700 transition-transform group-active:scale-95"></span>
-            <span class="text-[12px] font-bold text-lime-900">新規登録</span>
+            <span class="text-[12px] font-bold text-lime-900"><%= t('helpers.link.signup') %></span>
           <% end %>
         </div>
         <div>
           <%= link_to login_path, data: { turbo: :false }, class: "flex flex-col items-center gap-1 group" do %>
             <span class="icon-[lucide--log-in] text-xl text-lime-700 transition-transform group-active:scale-95"></span>
-            <span class="text-[12px] font-bold text-lime-900">ログイン</span>
+            <span class="text-[12px] font-bold text-lime-900"><%= t('helpers.link.login') %></span>
           <% end %>
         </div>
       </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
       <%= render 'layouts/header' %>
     </div>
     <div id="main" class="overflow-y-auto grow">
-      <div id="flash_messages" class="fixed top-[10dvh] left-0 right-0 z-100 pointer-events-none">
+      <div id="flash_messages" class="fixed sm:top-[10dvh] sm:top-[10dvh] lg:top-[8dvh] left-0 right-0 z-100 pointer-events-none">
         <%= render 'shared/flash_messages' %>
       </div>
 

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,24 +1,21 @@
-<div class="flex-grow w-full flex bg-gray-100 p-6 justify-center items-start">
-  <div class="w-full max-w-md bg-white p-6 shadow-md rounded-lg space-y-4">
-    <h2 class="text-xl font-bold text-gray-800">パスワードの変更</h2>
+<div class="min-h-full bg-lime-50 flex flex-col justify-center items-center py-8 px-4 sm:px-6 lg:px-8">
+  <h2 class="text-2xl font-extrabold text-lime-800 text-center mb-4">パスワードの更新</h2>
 
-    <%= form_with url: password_update_path, method: :patch, local: true, class: "space-y-4" do |f| %>
-      <div>
-        <%= f.label :password, "新しいパスワード", class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.password_field :password, required: true, minlength: 6, class: "w-full p-2 border border-gray-400 rounded-lg" %>
-      </div>
-
-      <div>
-        <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.password_field :password_confirmation, required: true, class: "w-full p-2 border border-gray-400 rounded-lg" %>
-      </div>
-
-      <%= f.submit "パスワードを更新する", class: "w-full bg-gray-800 hover:bg-gray-700 text-white font-semibold py-2 rounded-lg transition duration-200 cursor-pointer" %>
+  <div class="w-full max-w-sm bg-amber-100/60 rounded-2xl shadow-xl p-6 space-y-2 border border-amber-200">
+    <%= form_with url: password_update_path, method: :patch, local: true, id: "password-reset-form", data: { turbo: false }, class: "space-y-6" do |f| %>
+      <%# URLハッシュから取得したトークンを隠しフィールドで保持する %>
+      <%= hidden_field_tag :access_token, params[:access_token] || cookies[:rails_access_token], id: "hidden_access_token" %>
+      
+        <div>
+          <%= f.label :password, "新しいパスワード", class: "block text-base font-semibold text-amber-800 mb-2" %>
+          <%= f.password_field :password, required: true, minlength: 6, class: "w-full p-3 border border-amber-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent transition duration-200 ease-in-out bg-white text-lime-800 shadow-sm", placeholder: "入力してください" %>
+        </div>
+        <div>
+          <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "block text-base font-semibold text-amber-800 mb-2" %>
+          <%= f.password_field :password_confirmation, required: true, class: "w-full p-3 border border-amber-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent transition duration-200 ease-in-out bg-white text-lime-800 shadow-sm", placeholder: "もう一度入力してください" %>
+        </div>
+      <%= f.submit t('helpers.submit.password.update'), class: "w-full bg-rose-500 hover:bg-rose-600 text-white font-bold py-3 px-6 rounded-full shadow-lg transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-opacity-50 tracking-wide mt-2" %>
     <% end %>
-
-    <div class="mt-4 text-center">
-      <%= link_to "キャンセル", root_path, class: "text-sm text-gray-600 hover:underline" %>
-    </div>
   </div>
 </div>
 

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,0 +1,23 @@
+<div class="flex-grow w-full flex bg-gray-100 p-6 justify-center items-start">
+  <div class="w-full max-w-md bg-white p-6 shadow-md rounded-lg space-y-4">
+    <h2 class="text-xl font-bold text-gray-800">パスワードの変更</h2>
+
+    <%= form_with url: password_update_path, method: :patch, local: true, class: "space-y-4" do |f| %>
+      <div>
+        <%= f.label :password, "新しいパスワード", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.password_field :password, required: true, minlength: 6, class: "w-full p-2 border border-gray-400 rounded-lg" %>
+      </div>
+
+      <div>
+        <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.password_field :password_confirmation, required: true, class: "w-full p-2 border border-gray-400 rounded-lg" %>
+      </div>
+
+      <%= f.submit "パスワードを更新する", class: "w-full bg-gray-800 hover:bg-gray-700 text-white font-semibold py-2 rounded-lg transition duration-200 cursor-pointer" %>
+    <% end %>
+
+    <div class="mt-4 text-center">
+      <%= link_to "キャンセル", root_path, class: "text-sm text-gray-600 hover:underline" %>
+    </div>
+  </div>
+</div>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -21,3 +21,23 @@
     </div>
   </div>
 </div>
+
+<script>
+  // Rails 7 の Turbo 遷移に対応させるため、turbo:load イベントを使用
+  document.addEventListener("turbo:load", () => {
+    // 1. URLのハッシュを取得
+    const hash = window.location.hash;
+    
+    if (hash && hash.includes("access_token=")) {
+      // 2. ハッシュを解析してトークンを取り出す
+      const params = new URLSearchParams(hash.replace("#", "?"));
+      const token = params.get("access_token");
+      
+      // 3. 隠しフィールドにセット
+      const hiddenInput = document.getElementById("hidden_access_token");
+      if (hiddenInput) {
+        hiddenInput.value = token;
+      }
+    }
+  });
+</script>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,0 +1,8 @@
+<div class="max-w-md mx-auto bg-white p-6 shadow rounded">
+  <h2 class="text-xl font-bold mb-4">パスワードを再設定する</h2>
+  <%= form_with url: password_reset_path, local: true do |f| %>
+    <%= f.label :email, "登録済みのメールアドレス" %>
+    <%= f.email_field :email, required: true, class: "w-full p-2 border rounded mb-4" %>
+    <%= f.submit "再設定メールを送信", class: "w-full bg-gray-800 text-white p-2 rounded" %>
+  <% end %>
+</div>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,8 +1,19 @@
-<div class="max-w-md mx-auto bg-white p-6 shadow rounded">
-  <h2 class="text-xl font-bold mb-4">パスワードを再設定する</h2>
-  <%= form_with url: password_reset_path, local: true do |f| %>
-    <%= f.label :email, "登録済みのメールアドレス" %>
-    <%= f.email_field :email, required: true, class: "w-full p-2 border rounded mb-4" %>
-    <%= f.submit "再設定メールを送信", class: "w-full bg-gray-800 text-white p-2 rounded" %>
-  <% end %>
+<div class="min-h-full bg-lime-50 flex flex-col justify-center items-center py-8 px-4 sm:px-6 lg:px-8">
+  <h2 class="text-2xl font-extrabold text-lime-800 text-center mb-4">パスワードを再設定</h2>
+
+  <div class="w-full max-w-sm bg-amber-100/60 rounded-2xl shadow-xl p-6 space-y-4 border border-amber-200">
+  <p class="text-sm text-amber-800 text-center mb-4"> 登録済みメールアドレスに、再設定用のリンクをお送りします。 </p>
+    <%= form_with url: password_reset_path, local: true, class: "space-y-4" do |f| %>
+      <div>
+        <%= f.label :email, "登録済みのメールアドレス", class: "block text-base font-semibold text-lime-900 mb-2" %>
+        <%= f.email_field :email, required: true, class: "w-full p-2 border border-amber-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent transition duration-200 ease-in-out bg-white text-lime-800 shadow-sm" %>
+      </div>
+      
+      <%= f.submit t('helpers.submit.password.create'), class: "w-full bg-lime-600 hover:bg-lime-700 text-white font-bold py-3 px-6 rounded-full shadow-md transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-opacity-50 tracking-wide mt-2" %>
+    <% end %>
+    
+    <div class="mt-6 text-center">
+      <%= link_to t('helpers.link.back_to_login'), login_path, class: "text-sm font-medium text-lime-600 hover:text-lime-800 transition-colors duration-200" %>
+    </div>
+  </div>
 </div>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -15,7 +15,7 @@
         <% end %>
       </div>
       <!-- Centered Month and Year -->
-      <h2 class="text-3xl sm:text-3xl font-black tracking-tight text-amber-900">
+      <h2 class="text-2xl sm:text-3xl font-black tracking-tight text-amber-900">
         <%= start_date.year %>年 <%= t('date.month_names')[start_date.month] %>
       </h2>
       <!-- Month & Year Next Buttons -->
@@ -34,19 +34,21 @@
     </div>
 
     <!-- Today Button centered below -->
-    <div class="flex justify-center mt-2">
+    <div class="flex justify-center my-2.5 lg:my-4">
       <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view,
-          class: "text-sm font-bold text-amber-700 bg-amber-200/50 hover:bg-amber-200 px-3 py-2 rounded-full transition-colors" %>
+          class: "text-xs font-bold text-amber-700 bg-amber-200/50 hover:bg-amber-200 px-3 py-1.5 rounded-full transition-colors" %>
     </div>
   </div>
 
-  <div class="max-w-full mx-2 bg-amber-100 rounded-3xl sm:rounded-3xl py-6 px-1 shadow-md border border-amber-200/50">
+  <div class="max-w-full mx-2 bg-amber-100 rounded-3xl sm:rounded-2xl py-3 px-1 shadow-md border border-amber-200/50">
     <div class="grid grid-cols-7 mb-2">
       <% date_range.slice(0, 7).each do |day| %>
-        <div class="text-center">
-          <span class="text-md sm:text-md font-black text-amber-800 uppercase tracking-wider">
-            <%= t('date.abbr_day_names')[day.wday] %>
-          </span>
+        <div class="grid justify-items-stretch gap-2">
+          <div class="text-center py-1">
+            <span class="text-md sm:text-md font-black text-lime-700">
+              <%= t('date.abbr_day_names')[day.wday] %>
+            </span>
+          </div>
         </div>
       <% end %>
     </div>
@@ -54,14 +56,14 @@
       <% date_range.each do |day| %>
         <%= content_tag :div, class: "relative group transition-all" do %>
           <!-- Increased cell size on mobile and ensured fixed height with hidden scrollbars -->
-          <div class="aspect-[3/4] min-h-[65px] flex flex-col items-stretch transition-all overflow-hidden
+          <div class="aspect-[4/5] min-h-[65px] flex flex-col items-stretch transition-all overflow-hidden
             <%= day.month == start_date.month ? 'bg-amber-50' : 'bg-lime-100/50 opacity-40' %>
-            border border-lime-400/50 cursor-pointer rounded-md lg:rounded-xl"
+            border border-lime-400/50 cursor-pointer rounded-md lg:rounded-x2 my-1"
           >
             <!-- Date link positioned at the top-center of the cell -->
             <div class="text-center pt-1 relative inline-flex items-center justify-center">
               <% if day == Date.today %>
-                <div class="absolute w-6 h-6 bg-rose-200/80 rounded-full blur-xs"></div>
+                <div class="absolute w-6 h-6 bg-rose-200/70 rounded-full blur-xs"></div>
               <% end %>
               <%= link_to day.day, date_index_diaries_path(date: day), class: "text-base font-bold transition-colors text-amber-800 hover:text-rose-600 #{day == Date.today ? 'relative': ''}" %>
             </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -100,6 +100,9 @@ ja:
         create: 登録する
         submit: ログイン
         update: 更新する
+      password:
+        create: 再設定メールを送信
+        update: パスワードを更新する
     message:
       no_diary_found: 該当する日記はありません。
       no_diary_on_day: この日の日記はありません。
@@ -107,3 +110,5 @@ ja:
       back_to_calendar: カレンダーに戻る
       go_to_login: ← ログインはこちら
       go_to_signup: → 新規登録はこちら
+      back_to_login: ← ログインページに戻る
+      forget_password: パスワードをお忘れですか？

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -107,6 +107,9 @@ ja:
       no_diary_found: 該当する日記はありません。
       no_diary_on_day: この日の日記はありません。
     link:
+      signup: 新規登録
+      login: ログイン
+      logout: ログアウト
       back_to_calendar: カレンダーに戻る
       go_to_login: ← ログインはこちら
       go_to_signup: → 新規登録はこちら

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -98,6 +98,7 @@ ja:
         edit: 編集する
       user:
         create: 登録する
+        submit: ログイン
         update: 更新する
     message:
       no_diary_found: 該当する日記はありません。
@@ -105,3 +106,4 @@ ja:
     link:
       back_to_calendar: カレンダーに戻る
       go_to_login: ← ログインはこちら
+      go_to_signup: → 新規登録はこちら

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,12 +2,19 @@ Rails.application.routes.draw do
   root 'top#index'
 
   # 認証用ルート
-  get 'auth', to: 'auth#index'
   get  'signup', to: 'auth#signup'
   post 'signup', to: 'auth#create_signup'
   get  'login',  to: 'auth#login'
   post 'login',  to: 'auth#create_login'
   delete 'logout', to: 'auth#destroy'
+
+  # パスワードリセットリクエスト
+  get  'password/reset', to: 'passwords#new', as: :new_password_reset
+  post 'password/reset', to: 'passwords#create'
+
+  # パスワード更新画面
+  get  'password/edit',  to: 'passwords#edit', as: :edit_password
+  patch 'password/update', to: 'passwords#update'
   
   resource :mypage, only: [:show, :edit, :update]
 


### PR DESCRIPTION
## 概要
 - ログインページのデザインを整える
 - パスワード変更・再設定ページのデザインを整える

## 関連issue
#115 

## やったこと
 - ログインページのUIを整えた
 - パスワード変更・再設定用のルートを追加
 - `passwords_controller.rb`を作成
 - パスワードを変更・再設定するためのページを作成
 - リンクの文言をi18n化
 - フラッシュメッセージの表示位置を調整

## やらないこと
 - 

## テスト／完了確認
 - [x] ログインが問題なくできる
 - [x] パスワードを変更することができる
 - [x] パスワードリセット用のメールが届く
 - [x] パスワード再設定ができる
 - [x] 変更・再設定したパスワードでログインができる