### PR TITLE
Feature/#116 マイページのデザインを整える

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -17,8 +17,6 @@ class AuthController < ApplicationController
       if supabase_response[:success]
         @user.supabase_uid = supabase_response[:uid]
 
-        logger.debug "--- User UID to be saved: #{@user.supabase_uid} ---"
-        
         # passwordはattr_accessorのため、saveしてもDBには保存されない
         if @user.save
           # 3. ログイン状態にする

--- a/app/controllers/families/families_controller.rb
+++ b/app/controllers/families/families_controller.rb
@@ -1,6 +1,6 @@
 module Families
   class FamiliesController < ApplicationController
-    before_action :require_login
+    before_action :authenticate_user!
     before_action :set_family, only: [:edit, :update]
     before_action :authorize_owner, only: [:edit, :update]
 

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,65 +1,47 @@
-<div class="flex flex-col items-center pt-4">
-  <div class="w-full max-w-2xl bg-white p-8 rounded-xl shadow-lg">
-    <h1 class="text-3xl font-bold text-gray-800 mb-6 border-b pb-2">マイページ</h1>
-    
-    <%# ---------------------------------------------------- %>
-    <%# 1. プロフィール情報  %>
-    <%# ---------------------------------------------------- %>
-    <section class="mb-8 p-4 border rounded-lg bg-gray-50">
-      <h2 class="text-xl font-semibold text-gray-700 mb-4">ユーザー情報</h2>
-      
-      <div class="space-y-3">
-        <div class="flex items-end">
-          <div>
-            <span class="font-medium text-gray-600">アイコン:</span>
-          </div>
-          <div>
-            <%= image_tag @user.display_avatar, class: "w-24 h-24 rounded-full object-cover" %>
-          </div>
+<div class="min-h-full bg-lime-50 flex flex-col items-center py-6 px-4 sm:px-6 lg:px-8">
+  <h1 class="text-2xl font-bold text-amber-900 text-center mb-4">マイページ</h1>
+
+  <div class="w-full max-w-md mb-8 bg-amber-50 rounded-3xl shadow-md overflow-hidden border border-amber-300">
+    <div class="px-6 py-8 flex flex-col items-center border-b border-amber-300 bg-white/50">
+      <div class="relative mb-2">
+        <div class="size-28 rounded-full bg-gray-200 overflow-hidden ring-3 ring-amber-600 shadow-xs">
+          <%= image_tag current_user.display_avatar, class: "w-full h-full object-cover" %>
         </div>
-
-        <p>
-          <span class="font-medium text-gray-600">表示名:</span>
-          <span class="text-gray-900 font-bold ml-2"><%= @user.name %></span>
-        </p>
-        
-        <p>
-          <span class="font-medium text-gray-600">メールアドレス:</span>
-          <span class="text-gray-800 ml-2"><%= @user.email %></span>
-        </p>
-        
-        <p>
-          <span class="font-medium text-gray-600">Supabase UID:</span>
-          <span class="text-gray-800 ml-2 break-all"><%= @user.supabase_uid %></span>
-        </p>
-
-        <p>
-          <span class="font-medium text-gray-600">所属している家族（グループ）:</span>
-          <span class="text-gray-800 ml-2 break-all">
-            <% if @user.family.present? %>
-              <%= @user.family.name %>
-            <% else %>
-              所属している家族なし
-            <% end %></span>
-        </p>
       </div>
-    </section>
+      
+      <h2 class="text-lg font-extrabold text-amber-900 mb-4"><%= current_user.name %></h2>
+      
+      <%= link_to edit_mypage_path, class: "flex items-center justify-center w-full py-3 px-6 bg-lime-500 hover:bg-lime-600 text-white font-bold rounded-full shadow-md transition duration-300 ease-in-out transform hover:scale-105" do %>
+        <span class="icon-[mdi--account-edit] mr-2 text-xl"></span>
+        ユーザー情報を確認
+      <% end %>
+    </div>
 
-    <div class="mt-8 grid grid-cols-2 gap-4 place-items-center">
-      <div id="user_edit_button" class="">
-        <%= button_to "ユーザー情報を確認", edit_mypage_path, method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2.5" %>
+    <div class="p-6 space-y-4">
+      <div class="flex items-center mb-4">
+        <span class="icon-[fluent-mdl2--family] text-2xl text-amber-600 mr-2"></span>
+        <h3 class="text-md font-bold text-amber-900">家族の情報</h3>
       </div>
-      <div id="group_button">
-        <% if current_user.family.present? %>
-          <%= button_to "家族（グループ）を確認", family_path(current_user.family.id), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2.5" %>
-        <% else %>
-          <%= button_to "家族（グループ）に入る・確認", new_family_path, method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2.5" %>
+
+      <% if current_user.family.present? %>
+        <div class="bg-white p-4 rounded-2xl border border-amber-100 shadow-sm mb-4">
+          <p class="text-amber-900 font-semibold text-md text-center"><%= current_user.family.name %></p>
+        </div>
+        <%= link_to family_path(current_user.family.id), class: "flex items-center justify-center w-full py-3 px-6 mb-2 bg-lime-500 hover:bg-lime-600 text-white font-bold rounded-full shadow-md transition duration-300 ease-in-out transform hover:scale-105" do %>
+          <span class="icon-[material-symbols--family-home-rounded] mr-2 text-xl"></span>
+          家族の情報を確認
         <% end %>
-      </div>
+      <% else %>
+        <p class="text-amber-800 text-sm text-center mb-6 italic">家族グループに所属していません</p>
+        <%= link_to new_family_path, class: "flex items-center justify-center w-full py-3 px-6 mb-2 bg-lime-500 hover:bg-lime-600 text-white font-bold rounded-full shadow-md transition duration-300 ease-in-out transform hover:scale-105" do %>
+          <span class="icon-[mdi--house-plus] mr-2 text-xl"></span>
+          家族（グループ）に入る・作成
+        <% end %>
+      <% end %>
     </div>
   </div>
+</div>
 
-  <div>
-    <%= render 'layouts/footer' %>
-  </div>
+<div>
+  <%= render 'layouts/footer' %>
 </div>


### PR DESCRIPTION
## 概要
マイページのデザインを整える

## 関連issue
#116 

## やったこと
 - マイページのデザインをアプリデザインに沿ったものに一新
 - `families/families_controller.rb`の`require_login`メソッドを`authenticate_user!`に置き換え

## やらないこと
 - 家族情報を表示するページのデザインを整える
 - ユーザー情報を変更・更新するページのデザインを整える

## テスト／完了確認
 - [x] マイページのデザインがモバイル端末に最適化されていることを確認