### PR TITLE
Feature/#118 家族情報ページのデザインを整える

### DIFF
--- a/app/views/auth/login.html.erb
+++ b/app/views/auth/login.html.erb
@@ -23,7 +23,7 @@
       </div>
 
       <%# ログインボタン %>
-      <%= f.submit t('helpers.submit.user.submit'), class: "w-full bg-lime-600 hover:bg-lime-700 text-white font-bold py-3 px-6 rounded-full shadow-md transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-opacity-50 tracking-wide" %>
+      <%= f.submit t('helpers.submit.user.submit'), class: "w-full bg-lime-600 hover:bg-lime-700 text-white font-bold py-3 px-6 rounded-full shadow-md transition duration-300 ease-in-out" %>
     <% end %>
   </div>
 

--- a/app/views/families/families/edit.html.erb
+++ b/app/views/families/families/edit.html.erb
@@ -1,63 +1,98 @@
-<div id="edit_family" class="text-center">
-  <h1 class="text-3xl font-bold m-6">家族（グループ）の編集</h1>
-  <div id="family_form">
-    <%= form_with model: @family, url: family_path(id: @family.id), data: { turbo: false }, local: true do |f| %>
-      <div>
-        <div>
-          <%= f.label :name, "家族（グループ）名", class: "font-bold" %>
-        </div>
-        <div>
-          <%= f.text_field :name, class: "border border-default-medium rounded-base" %>
-          <%= f.submit "更新", data: { turbo: false }, class: "box-border border border-default m-2 pl-2 pr-2" %>
-        </div>
-      </div>
-    <% end %>
-  </div>
+<div class="min-h-full bg-lime-100 flex flex-col items-center py-8 px-4 sm:px-6 lg:px-8">
+  <h1 class="text-2xl font-extrabold text-lime-900 text-center mb-6">家族情報の編集</h1>
 
-  <div id="family_info">
-    <div class="mt-6 m-2">
-      <span class="font-bold">家族（グループ）メンバー一覧</span>
+  <div class="w-full max-w-md space-y-6">
+    <div class="bg-white rounded-2xl shadow-md p-5 border border-amber-200">
+      <div class="flex items-center mb-4">
+        <span class="icon-[material-symbols--family-group-rounded] text-2xl text-amber-600 mr-3"></span>
+        <h2 class="text-md font-bold text-amber-800"><%= t('activerecord.attributes.family.name') %>を編集</h2>
+      </div>
+      <%= form_with model: @family, url: family_path(id: @family.id), data: { turbo: false }, local: true, class: "space-y-4" do |f| %>
+        <div class="flex flex-col space-y-3">
+          <%= f.text_field :name, class: "w-full p-3 bg-lime-50 border border-lime-400 rounded-xl text-lg font-bold text-lime-900 focus:ring-2 focus:ring-lime-500 focus:border-transparent outline-none transition-all", placeholder: "家族名を入力" %>
+          <%= f.submit t('helpers.submit.family.update'), data: { turbo: false }, class: "w-full py-2 bg-amber-500 hover:bg-amber-600 text-white font-bold rounded-full shadow-sm transition-all active:scale-95 cursor-pointer" %>
+        </div>
+      <% end %>
     </div>
-    <div>
-      <ul class="list-disc list-inside">
+    
+    <div class="bg-white rounded-2xl shadow-md p-5 border border-amber-200">
+      <div class="flex items-center mb-4">
+        <span class="icon-[mdi--account-group] text-2xl text-amber-600 mr-2"></span>
+        <h2 class="text-md font-bold text-amber-800"><%= t('activerecord.attributes.family.members') %></h2>
+      </div>
+      <ul class="space-y-3 my-4">
         <% @members.each do |member| %>
-          <li>
-            <%= member.name %>
-            <% if member.id == @family.owner_id %>（管理者）<% end %>
+          <li class="flex items-center justify-between bg-amber-100/50 rounded-2xl p-3 shadow-sm">
+            <div class="flex items-center">
+              <div class="size-10 rounded-full flex items-center justify-center mr-3 shadow-inner overflow-hidden">
+                <%= image_tag member.display_avatar, class: "w-full h-full object-cover" %>
+              </div>
+              <div>
+                <span class="font-semibold text-md text-amber-900"><%= member.name %></span>
+              </div>
+            </div>
+            <% if member.id == @family.owner_id %>
+              <span class="flex items-center text-xs font-medium text-lime-900 bg-lime-300/70 px-2 py-1 rounded-full">
+              <span class="icon-[mdi--shield-check] mr-1"></span>管理者 </span>
+            <% end %>
           </li>
         <% end %>
       </ul>
-    </div>
 
-    <div class="mt-10">
-      <span class="font-bold">子ども一覧</span>
-    </div>
-    <div class="my-2">
-      <ul class="list-disc list-inside">
-        <% @family.children.each do |child| %>
-          <li>
-            <%= child.name %>
-          </li>
+      <div class="space-y-3">
+        <% if current_user.id == @family.owner_id %>
+          <%= link_to new_family_member_path(family_id: @family.id), class: "flex items-center justify-center w-full py-3 bg-lime-500 hover:bg-lime-600 text-white font-bold rounded-full shadow-md transition-all active:scale-95" do %>
+            <span class="icon-[mdi--account-plus] mr-2 text-lg"></span><%= t('helpers.button.family.add_member') %>
+          <% end %>
+          <% if @members.count > 1 %>
+            <%= link_to family_members_path(family_id: @family.id), class: "flex items-center justify-center w-full py-3 bg-white border-2 border-rose-400 text-rose-500 hover:bg-rose-50 font-bold rounded-full transition-all active:scale-95" do %>
+              <span class="icon-[mdi--account-remove] mr-2 text-lg"></span><%= t('helpers.button.family.delete_member') %>
+            <% end %>
+          <% end %>
+        <% else %>
+          <%= link_to family_members_path(family_id: @family.id), class: "flex items-center justify-center w-full py-3 bg-white border-2 border-rose-400 text-rose-500 hover:bg-rose-50 font-bold rounded-full transition-all active:scale-95" do %>
+            <span class="icon-[mdi--logout] mr-2 text-lg"></span><%= t('helpers.button.family.optout_family') %>
+          <% end %>
         <% end %>
-      </ul>
+      </div>
     </div>
-    <% if @family.children.count > 0 && current_user.id == @family.owner_id %>
-      <div>
-        <%= button_to "子どもの情報を編集・削除", family_children_path(family_id: @family.id), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
-        <%= button_to "子どもの情報を追加", new_family_child_path(family_id: @family.id), method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
+      
+      <div class="bg-white rounded-2xl shadow-md p-5 border border-amber-200">
+        <div class="flex items-center mb-4">
+          <span class="icon-[mdi--baby-face-outline] text-2xl text-amber-600 mr-2"></span>
+          <h2 class="text-md font-bold text-amber-800"><%= t('activerecord.attributes.family.children') %></h2>
+        </div>
+        <% if @family.children.any? %>
+          <ul class="grid grid-cols-2 gap-3 mb-6">
+            <% @family.children.each do |child| %>
+              <li class="bg-amber-50 rounded-2xl p-4 text-center border border-amber-100 shadow-sm">
+                <span class="font-extrabold text-amber-900"><%= child.name %></span>
+              </li>
+            <% end %>
+          </ul>
+        <% else %>
+          <p class="text-amber-800 text-sm text-center mb-6 italic bg-amber-50 py-4 rounded-xl border border-amber-100"><%= t('helpers.message.no_children_data') %></p>
+        <% end %>
+        
+        <div class="space-y-3">
+          <%= link_to new_family_child_path(family_id: @family.id), data: { turbo: false }, class: "flex items-center justify-center w-full py-3 bg-lime-500 hover:bg-lime-600 text-white font-bold rounded-full shadow-md transition-all active:scale-95" do %>
+            <span class="icon-[mdi--plus-circle] mr-2 text-lg"></span><%= t('helpers.button.children.add_child') %>
+          <% end %>
+          <% if @family.children.count > 0 %>
+            <%= link_to family_children_path(family_id: @family.id), data: { turbo: false }, class: "flex items-center justify-center w-full py-3 bg-amber-100 hover:bg-amber-200 text-amber-800 font-bold rounded-full transition-all active:scale-95" do %>
+              <span class="icon-[mdi--account-edit] mr-2 text-lg"></span><%= t('helpers.button.children.edit_children') %>
+            <% end %>
+          <% end %>
+        </div>
       </div>
-    <% elsif current_user.id == @family.owner_id %>
-      <div>
-        <%= button_to "子どもの情報を追加", new_family_child_path(family_id: @family.id), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
-      </div>
+      
+    <div class="pt-4 text-center"> <%= link_to family_path(@family), data: { turbo: false }, class: "inline-flex items-center text-lime-900 font-bold hover:text-amber-700 transition-colors" do %>
+      <span class="icon-[mdi--arrow-left] mr-1"></span> <%= t('helpers.link.back_to_family_page') %>
     <% end %>
+    </div>
   </div>
+</div>
 
-  <div class="my-8">
-    <%= link_to "戻る", family_path(@family), data: { turbo: false } %>
-  </div>
-
-  <div>
-    <%= render 'layouts/footer' %>
-  </div>
+<div>
+  <%= render 'layouts/footer' %>
 </div>

--- a/app/views/families/families/edit.html.erb
+++ b/app/views/families/families/edit.html.erb
@@ -33,7 +33,9 @@
             </div>
             <% if member.id == @family.owner_id %>
               <span class="flex items-center text-xs font-medium text-lime-900 bg-lime-300/70 px-2 py-1 rounded-full">
-              <span class="icon-[mdi--shield-check] mr-1"></span>管理者 </span>
+                <span class="icon-[mdi--shield-check] mr-1"></span>
+                <%= t('activerecord.attributes.family.owner') %>
+              </span>
             <% end %>
           </li>
         <% end %>

--- a/app/views/families/families/show.html.erb
+++ b/app/views/families/families/show.html.erb
@@ -1,74 +1,106 @@
-<div id="show_family" class="text-center">
-  <h1 class="text-3xl font-bold m-6">家族（グループ）の情報</h1>
-
-  <div id="family_info">
-    <div class="mt-8">
-      <span class="font-bold">家族（グループ）名：</span> <%= @family.name %>
-    </div>
-    <% if current_user.id == @family.owner_id %>
-      <div class="my-2">
-        <%= button_to '家族（グループ）名を編集する', edit_family_path, method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium rounded-full text-sm px-4 py-2 m-2" %>
-      </div>
-    <% end %>
-
-    <div class="mt-8">
-      <span class="font-bold">家族（グループ）メンバー一覧</span>
-    </div>
-    <div class="my-2">
-      <ul class="list-disc list-inside">
-        <% @members.each do |member| %>
-          <li>
-            <%= member.name %>
-            <% if member.id == current_user.id %>（あなた）<% end %>
-            <% if member.id == @family.owner_id %>（管理者）<% end %>
-          </li>
+<div class="min-h-screen bg-lime-100 flex flex-col items-center py-8 px-4 sm:px-6 lg:px-8">
+  <h1 class="text-2xl font-extrabold text-lime-900 text-center mb-6">家族の情報</h1>
+  
+  <div class="w-full max-w-md space-y-6">
+    <div class="bg-white rounded-2xl shadow-md p-5 border border-amber-200">
+      <div class="flex items-center justify-between mb-4">
+        <div class="flex items-center">
+          <span class="icon-[material-symbols--family-group-rounded] text-2xl text-amber-600 mr-3"></span>
+          <h2 class="text-md font-bold text-amber-800">家族（グループ）名</h2>
+        </div>
+        <% if current_user.id == @family.owner_id %>
+          <%= link_to edit_family_path, class: "size-8 text-amber-600 hover:text-lime-600 transition-colors p-2 bg-amber-50 rounded-full shadow-sm" do %>
+            <span class="icon-[mdi--pencil] text-lg"></span>
+          <% end %>
         <% end %>
-      </ul>
+      </div>
+      <div class="bg-lime-200/70 rounded-2xl p-4 text-center">
+        <p class="text-lg font-extrabold text-lime-900"><%= @family.name %></p>
+      </div>
     </div>
-    <% if @members.count > 1 && current_user.id == @family.owner_id %>
-      <div>
-        <%= button_to "メンバーを削除", family_members_path(family_id: @family.id), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
-        <%= button_to "メンバーを追加", new_family_member_path(family_id: @family.id), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
+    
+    <div class="bg-white rounded-2xl shadow-md p-5 border border-amber-200">
+      <div class="flex items-center mb-4">
+        <span class="icon-[mdi--account-group] text-2xl text-amber-600 mr-2"></span>
+        <h2 class="text-md font-bold text-amber-800">メンバー一覧</h2>
       </div>
-    <% elsif @members.count <= 1 && current_user.id == @family.owner_id %>
-      <div>
-        <%= button_to "メンバーを追加", new_family_member_path(family_id: @family.id), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
-      </div>
-    <% else %>
-      <div>
-        <%= button_to "家族から脱退", family_members_path(family_id: @family.id), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
-      </div>
-    <% end %>
-
-    <div class="mt-10">
-      <span class="font-bold">子ども一覧</span>
-    </div>
-    <div class="my-2">
-      <ul class="list-disc list-inside">
-        <% @family.children.each do |child| %>
-          <li>
-            <%= child.name %>
-          </li>
+        <ul class="space-y-3 mb-4">
+          <% @members.each do |member| %>
+            <li class="flex items-center justify-between bg-amber-100/50 rounded-2xl p-3 shadow-sm">
+              <div class="flex items-center">
+                <div class="size-10 rounded-full flex items-center justify-center mr-3 shadow-inner">
+                  <%= image_tag member.display_avatar, class: "rounded-full" %>
+                </div>
+                <div>
+                  <span class="<%= member.id == current_user.id ? "bg-rose-200/70 font-semibold text-md text-amber-900" : "font-semibold text-md text-amber-900" %>"><%= member.name %></span>
+                </div>
+              </div>
+              <% if member.id == @family.owner_id %>
+                <span class="flex items-center text-xs font-medium text-lime-900 bg-lime-300/70 px-2 py-1 rounded-full">
+                  <span class="icon-[mdi--shield-check] mr-1"></span>管理者
+                </span>
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
+        
+      <div class="space-y-3">
+        <% if current_user.id == @family.owner_id %>
+          <%= link_to new_family_member_path(family_id: @family.id), class: "flex items-center justify-center w-full py-3 bg-lime-500 hover:bg-lime-600 text-white font-bold rounded-full shadow-md transition-all active:scale-95" do %>
+            <span class="icon-[mdi--account-plus] mr-2 text-lg"></span>メンバーを追加
+          <% end %>
+          <% if @members.count > 1 %>
+            <%= link_to family_members_path(family_id: @family.id), class: "flex items-center justify-center w-full py-3 bg-white border-2 border-rose-400 text-rose-500 hover:bg-rose-50 font-bold rounded-full transition-all active:scale-95" do %>
+              <span class="icon-[mdi--account-remove] mr-2 text-lg"></span>メンバーを削除
+            <% end %>
+          <% end %>
+        <% else %>
+          <%= link_to family_members_path(family_id: @family.id), class: "flex items-center justify-center w-full py-3 bg-white border-2 border-rose-400 text-rose-500 hover:bg-rose-50 font-bold rounded-full transition-all active:scale-95" do %>
+            <span class="icon-[mdi--logout] mr-2 text-lg"></span>家族から脱退
+          <% end %>
         <% end %>
-      </ul>
-    </div>
-    <% if @family.children.count > 0 && current_user.id == @family.owner_id %>
-      <div class="my-2">
-        <%= button_to "子どもの情報を編集・削除", family_children_path(family_id: @family.id), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
-        <%= button_to "子どもの情報を追加", new_family_child_path(family_id: @family.id), method: :get, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
       </div>
-    <% elsif current_user.id == @family.owner_id %>
-      <div class="my-2">
-        <%= button_to "子どもの情報を追加", new_family_child_path(family_id: @family.id), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium leading-5 rounded-full text-sm px-4 py-2 m-2" %>
-      </div>
-    <% end %>
     </div>
 
-  <div class="my-8">
-    <%= link_to 'マイページへ', mypage_path, data: { turbo: false } %>
-  </div>
+    <div class="bg-white rounded-2xl shadow-md p-6 border border-amber-200">
+      <div class="flex items-center mb-4">
+        <span class="icon-[mdi--baby-face-outline] text-2xl text-amber-600 mr-2"></span>
+        <h2 class="text-xl font-bold text-amber-900">子ども一覧</h2>
+      </div>
+      <% if @family.children.any? %>
+        <ul class="grid grid-cols-2 gap-3 mb-4">
+          <% @family.children.each do |child| %>
+            <li class="bg-amber-50 rounded-2xl p-4 text-center border border-amber-100 shadow-sm">
+              <span class="font-extrabold text-amber-900"><%= child.name %></span>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="text-amber-800 text-sm text-center mb-6 italic bg-amber-50 py-4 rounded-md">子どもの情報が登録されていません</p>
+      <% end %>
 
-  <div>
-    <%= render 'layouts/footer' %>
+      <% if current_user.id == @family.owner_id %>
+        <div class="space-y-3">
+          <%= link_to new_family_child_path(family_id: @family.id), class: "flex items-center justify-center w-full py-3 bg-lime-500 hover:bg-lime-600 text-white font-bold rounded-full shadow-md transition-all active:scale-95" do %>
+            <span class="icon-[mdi--plus-circle] mr-2 text-lg"></span>子どもの情報を追加
+          <% end %>
+          <% if @family.children.count > 0 %>
+            <%= link_to family_children_path(family_id: @family.id), class: "flex items-center justify-center w-full py-3 bg-amber-100 hover:bg-amber-200 text-amber-800 font-bold rounded-full transition-all active:scale-95" do %>
+              <span class="icon-[mdi--account-edit] mr-2 text-lg"></span>子どもの情報を編集・削除
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+    
+    <div class="pt-4 text-center">
+      <%= link_to mypage_path, class: "inline-flex items-center text-lime-900 font-medium" do %>
+        <span class="icon-[mdi--arrow-left] mr-1"></span> <%= t('helpers.link.back_to_mypage') %>
+      <% end %>
+    </div>
   </div>
+</div>
+
+<div>
+  <%= render 'layouts/footer' %>
 </div>

--- a/app/views/families/families/show.html.erb
+++ b/app/views/families/families/show.html.erb
@@ -1,4 +1,4 @@
-<div class="min-h-screen bg-lime-100 flex flex-col items-center py-8 px-4 sm:px-6 lg:px-8">
+<div class="min-h-full bg-lime-100 flex flex-col items-center py-8 px-4 sm:px-6 lg:px-8">
   <h1 class="text-2xl font-extrabold text-lime-900 text-center mb-6">家族の情報</h1>
   
   <div class="w-full max-w-md space-y-6">
@@ -6,10 +6,10 @@
       <div class="flex items-center justify-between mb-4">
         <div class="flex items-center">
           <span class="icon-[material-symbols--family-group-rounded] text-2xl text-amber-600 mr-3"></span>
-          <h2 class="text-md font-bold text-amber-800">家族（グループ）名</h2>
+          <h2 class="text-md font-bold text-amber-800"><%= t('activerecord.attributes.family.name') %></h2>
         </div>
         <% if current_user.id == @family.owner_id %>
-          <%= link_to edit_family_path, class: "size-8 text-amber-600 hover:text-lime-600 transition-colors p-2 bg-amber-50 rounded-full shadow-sm" do %>
+          <%= link_to edit_family_path, class: "size-8 text-amber-600 hover:text-lime-600 transition-colors p-2 bg-rose-50 rounded-full shadow-sm" do %>
             <span class="icon-[mdi--pencil] text-lg"></span>
           <% end %>
         <% end %>
@@ -20,52 +20,49 @@
     </div>
     
     <div class="bg-white rounded-2xl shadow-md p-5 border border-amber-200">
-      <div class="flex items-center mb-4">
-        <span class="icon-[mdi--account-group] text-2xl text-amber-600 mr-2"></span>
-        <h2 class="text-md font-bold text-amber-800">メンバー一覧</h2>
-      </div>
-        <ul class="space-y-3 mb-4">
-          <% @members.each do |member| %>
-            <li class="flex items-center justify-between bg-amber-100/50 rounded-2xl p-3 shadow-sm">
-              <div class="flex items-center">
-                <div class="size-10 rounded-full flex items-center justify-center mr-3 shadow-inner">
-                  <%= image_tag member.display_avatar, class: "rounded-full" %>
-                </div>
-                <div>
-                  <span class="<%= member.id == current_user.id ? "bg-rose-200/70 font-semibold text-md text-amber-900" : "font-semibold text-md text-amber-900" %>"><%= member.name %></span>
-                </div>
-              </div>
-              <% if member.id == @family.owner_id %>
-                <span class="flex items-center text-xs font-medium text-lime-900 bg-lime-300/70 px-2 py-1 rounded-full">
-                  <span class="icon-[mdi--shield-check] mr-1"></span>管理者
-                </span>
-              <% end %>
-            </li>
-          <% end %>
-        </ul>
-        
-      <div class="space-y-3">
+      <div class="flex items-center justify-between mb-4">
+        <div class="flex items-center">
+          <span class="icon-[mdi--account-group] text-2xl text-amber-600 mr-2"></span>
+          <h2 class="text-md font-bold text-amber-800"><%= t('activerecord.attributes.family.members') %></h2>
+        </div>
         <% if current_user.id == @family.owner_id %>
-          <%= link_to new_family_member_path(family_id: @family.id), class: "flex items-center justify-center w-full py-3 bg-lime-500 hover:bg-lime-600 text-white font-bold rounded-full shadow-md transition-all active:scale-95" do %>
-            <span class="icon-[mdi--account-plus] mr-2 text-lg"></span>メンバーを追加
-          <% end %>
-          <% if @members.count > 1 %>
-            <%= link_to family_members_path(family_id: @family.id), class: "flex items-center justify-center w-full py-3 bg-white border-2 border-rose-400 text-rose-500 hover:bg-rose-50 font-bold rounded-full transition-all active:scale-95" do %>
-              <span class="icon-[mdi--account-remove] mr-2 text-lg"></span>メンバーを削除
-            <% end %>
-          <% end %>
-        <% else %>
-          <%= link_to family_members_path(family_id: @family.id), class: "flex items-center justify-center w-full py-3 bg-white border-2 border-rose-400 text-rose-500 hover:bg-rose-50 font-bold rounded-full transition-all active:scale-95" do %>
-            <span class="icon-[mdi--logout] mr-2 text-lg"></span>家族から脱退
+          <%= link_to edit_family_path, class: "size-8 text-rose-600 p-2 bg-rose-100 rounded-full shadow-sm" do %>
+            <span class="icon-[mdi--user-edit] text-xl"></span>
           <% end %>
         <% end %>
       </div>
+      <ul class="space-y-3 mb-4">
+        <% @members.each do |member| %>
+          <li class="flex items-center justify-between bg-amber-100/50 rounded-2xl p-3 shadow-sm">
+            <div class="flex items-center">
+              <div class="size-10 rounded-full flex items-center justify-center mr-3 shadow-inner">
+                <%= image_tag member.display_avatar, class: "rounded-full" %>
+              </div>
+              <div>
+                <span class="<%= member.id == current_user.id ? "bg-rose-200/70 font-semibold text-md text-amber-900" : "font-semibold text-md text-amber-900" %>"><%= member.name %></span>
+              </div>
+            </div>
+            <% if member.id == @family.owner_id %>
+              <span class="flex items-center text-xs font-medium text-lime-900 bg-lime-300/70 px-2 py-1 rounded-full">
+                <span class="icon-[mdi--shield-check] mr-1"></span><%= t('activerecord.attributes.family.owner') %>
+              </span>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
     </div>
 
     <div class="bg-white rounded-2xl shadow-md p-6 border border-amber-200">
-      <div class="flex items-center mb-4">
-        <span class="icon-[mdi--baby-face-outline] text-2xl text-amber-600 mr-2"></span>
-        <h2 class="text-xl font-bold text-amber-900">子ども一覧</h2>
+      <div class="flex items-center justify-between mb-4">
+        <div class="flex items-center">
+          <span class="icon-[mdi--baby-face-outline] text-2xl text-amber-600 mr-2"></span>
+          <h2 class="text-xl font-bold text-amber-900"><%= t('activerecord.attributes.family.children') %></h2>
+        </div>
+        <% if current_user.id == @family.owner_id %>
+          <%= link_to edit_family_path, class: "size-8 text-rose-600 p-2 bg-rose-100 rounded-full shadow-sm" do %>
+            <span class="icon-[tabler--mood-edit] text-xl"></span>
+          <% end %>
+        <% end %>
       </div>
       <% if @family.children.any? %>
         <ul class="grid grid-cols-2 gap-3 mb-4">
@@ -76,20 +73,7 @@
           <% end %>
         </ul>
       <% else %>
-        <p class="text-amber-800 text-sm text-center mb-6 italic bg-amber-50 py-4 rounded-md">子どもの情報が登録されていません</p>
-      <% end %>
-
-      <% if current_user.id == @family.owner_id %>
-        <div class="space-y-3">
-          <%= link_to new_family_child_path(family_id: @family.id), class: "flex items-center justify-center w-full py-3 bg-lime-500 hover:bg-lime-600 text-white font-bold rounded-full shadow-md transition-all active:scale-95" do %>
-            <span class="icon-[mdi--plus-circle] mr-2 text-lg"></span>子どもの情報を追加
-          <% end %>
-          <% if @family.children.count > 0 %>
-            <%= link_to family_children_path(family_id: @family.id), class: "flex items-center justify-center w-full py-3 bg-amber-100 hover:bg-amber-200 text-amber-800 font-bold rounded-full transition-all active:scale-95" do %>
-              <span class="icon-[mdi--account-edit] mr-2 text-lg"></span>子どもの情報を編集・削除
-            <% end %>
-          <% end %>
-        </div>
+        <p class="text-amber-800 text-sm text-center mb-6 italic bg-amber-50 py-4 rounded-md"><%= t('helpers.message.no_children_data') %></p>
       <% end %>
     </div>
     

--- a/app/views/mypages/edit.html.erb
+++ b/app/views/mypages/edit.html.erb
@@ -1,7 +1,7 @@
-<div class="min-h-full bg-lime-50 flex flex-col items-center pb-8 px-4 sm:px-6 lg:px-8">
-  <h1 class="text-2xl font-bold text-amber-900 text-center my-4">プロフィール編集</h1>
+<div class="min-h-full bg-lime-100 flex flex-col items-center pb-8 px-4 sm:px-6 lg:px-8">
+  <h1 class="text-2xl font-bold text-lime-900 text-center my-4">プロフィール編集</h1>
 
-  <div class="w-full max-w-md bg-amber-50 rounded-3xl shadow-md p-4 space-y-7 border border-amber-200">
+  <div class="w-full max-w-md bg-amber-50/90 rounded-3xl shadow-md p-6 space-y-7 border border-amber-200">
     <div id="user_form">
     <%= form_with model: @user, url: mypage_path, method: :patch, data: { turbo: false }, local: true, class: "space-y-6" do |f| %>
       <div class="flex flex-col items-center space-y-3 mb-8">

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,5 +1,5 @@
-<div class="min-h-full bg-lime-50 flex flex-col items-center py-6 px-4 sm:px-6 lg:px-8">
-  <h1 class="text-2xl font-bold text-amber-900 text-center mb-4">マイページ</h1>
+<div class="min-h-full bg-lime-100 flex flex-col items-center py-6 px-4 sm:px-6 lg:px-8">
+  <h1 class="text-2xl font-bold text-lime-900 text-center mb-4">マイページ</h1>
 
   <div class="w-full max-w-md mb-8 bg-amber-50 rounded-3xl shadow-md overflow-hidden border border-amber-300">
     <div class="px-6 py-8 flex flex-col items-center border-b border-amber-300 bg-white/50">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -39,7 +39,10 @@ ja:
         birthday: 誕生日
         avatar: プロフィール画像
       family:
-        name: 家族の名前
+        name: 家族（グループ）名
+        members: メンバー一覧
+        children: 子ども一覧
+        owner: 管理者
       child:
         name: 子どもの名前
         birthday: 誕生日
@@ -100,12 +103,23 @@ ja:
         create: 登録する
         submit: ログイン
         update: 更新する
+      family:
+        update: 家族名を更新する
       password:
         create: 再設定メールを送信
         update: パスワードを更新する
     message:
-      no_diary_found: 該当する日記はありません。
-      no_diary_on_day: この日の日記はありません。
+      no_diary_found: 該当する日記はありません
+      no_diary_on_day: この日の日記はありません
+      no_children_data: 子どもの情報が登録されていません
+    button:
+      family:
+        add_member: メンバーを追加
+        delete_member: メンバーを削除
+        optout_family: 家族から脱退
+      children:
+        add_child: 子どもの情報を追加
+        edit_children: 子どもの情報を編集・削除
     link:
       signup: 新規登録
       login: ログイン
@@ -116,6 +130,7 @@ ja:
       back_to_login: ← ログインページに戻る
       forget_password: パスワードをお忘れですか？
       back_to_mypage: マイページに戻る
+      back_to_family_page: 家族の情報に戻る
   views:
     pagination:
       first: "&laquo;"


### PR DESCRIPTION
## 概要
家族情報ページのデザインを整える

## 関連issue
#118 
#119 

## やったこと
 - 家族情報を表示する `families/families/show`ページのデザインを整えた
 - 管理者ユーザーが家族情報を編集する `families/families/edit`ページのデザインを整えた
 - 見出しやボタン、リンクをi18n化

## やらないこと
 - 以下のページのデザインを整えることはしない
	 - 家族メンバーを追加するページ
	 - 家族メンバーを削除する／家族から脱退するページ
	 - 子どもの情報を追加するページ
	 - 子どもの情報を編集・削除するページ

## テスト／完了確認
 - [x] 家族情報表示画面がモバイル端末に最適化されたデザインになっていることを確認
 - [x] 管理者ユーザー用の家族設定画面がモバイル端末に最適化されたデザインになっていることを確認

## 備考
家族情報のページは管理者ユーザーと非管理者ユーザーで同一のページとなるため、 #119 もcloseとする