### PR TITLE
Feature/#120 家族を作成するページのデザインを整える

### DIFF
--- a/app/views/families/families/edit.html.erb
+++ b/app/views/families/families/edit.html.erb
@@ -22,21 +22,21 @@
       </div>
       <ul class="space-y-3 my-4">
         <% @members.each do |member| %>
-          <li class="flex items-center justify-between bg-amber-100/50 rounded-2xl p-3 shadow-sm">
-            <div class="flex items-center">
-              <div class="size-10 rounded-full flex items-center justify-center mr-3 shadow-inner overflow-hidden">
+          <li class="w-full flex flex-wrap items-center justify-between bg-amber-100/50 rounded-2xl p-3 shadow-sm">
+            <div class="w-full flex items-center">
+              <div class="size-10 rounded-full flex flex-none items-center justify-center mr-3 shadow-inner overflow-hidden">
                 <%= image_tag member.display_avatar, class: "w-full h-full object-cover" %>
               </div>
-              <div>
-                <span class="font-semibold text-md text-amber-900"><%= member.name %></span>
+              <div class="text-wrap">
+                <span class="<%= current_user.id == member.id ? "bg-rose-200 font-semibold text-md text-amber-900" : "font-semibold text-md text-amber-900" %>"><%= member.name %></span>
               </div>
+              <% if member.id == @family.owner_id %>
+                <div class="flex flex-nowrap items-center ml-auto text-xs font-medium text-lime-900 bg-lime-300/70 px-2 py-1 rounded-full">
+                  <span class="icon-[mdi--shield-check] mr-1"></span>
+                  <span class="text-nowrap"><%= t('activerecord.attributes.family.owner') %></span>
+                </div>
+              <% end %>
             </div>
-            <% if member.id == @family.owner_id %>
-              <span class="flex items-center text-xs font-medium text-lime-900 bg-lime-300/70 px-2 py-1 rounded-full">
-                <span class="icon-[mdi--shield-check] mr-1"></span>
-                <%= t('activerecord.attributes.family.owner') %>
-              </span>
-            <% end %>
           </li>
         <% end %>
       </ul>
@@ -87,10 +87,19 @@
           <% end %>
         </div>
       </div>
+
+    <!--
+    <div class="space-y-3">
+      <%= button_to family_path(family_id: @family.id), method: :delete, data: { turbo_confirm: "本当にこの家族を削除しますか？" }, class: "flex items-center justify-center w-full py-3 bg-rose-500/80 hover:bg-rose-600/80 text-white font-bold rounded-full shadow-md transition-all active:scale-95" do %>
+        <span class="icon-[mdi--house-off] mr-2 text-lg"></span><%= t('helpers.submit.family.destroy') %>
+      <% end %>
+    </div>
+    -->
       
-    <div class="pt-4 text-center"> <%= link_to family_path(@family), data: { turbo: false }, class: "inline-flex items-center text-lime-900 font-bold hover:text-amber-700 transition-colors" do %>
-      <span class="icon-[mdi--arrow-left] mr-1"></span> <%= t('helpers.link.back_to_family_page') %>
-    <% end %>
+    <div class="pt-4 text-center">
+      <%= link_to family_path(@family), data: { turbo: false }, class: "inline-flex items-center text-lime-900 font-bold hover:text-amber-700 transition-colors" do %>
+        <span class="icon-[mdi--arrow-left] mr-1"></span> <%= t('helpers.link.back_to_family_page') %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/families/families/new.html.erb
+++ b/app/views/families/families/new.html.erb
@@ -7,22 +7,6 @@
       <p class="text-amber-900 font-semibold text-sm"> <%= t('helpers.message.not_a_member_of_family') %> </p>
     </div>
 
-    <!--
-    <div class="bg-white rounded-3xl shadow-xl p-7 border border-amber-200">
-      <div class="flex items-center mb-6"> <span class="icon-[mdi--link-variant] text-2xl text-amber-600 mr-2"></span>
-        <h2 class="text-xl font-bold text-amber-900">家族に参加する</h2>
-      </div>
-      
-      <%= form_with url: root_path, data: { method: :get }, local: true, class: "space-y-5" do |f| %>
-        <div class="space-y-2">
-          <%= f.label :code, '共有された家族コード', class: "block text-sm font-bold text-amber-800 ml-1" %>
-          <%= f.text_field :code, class: "w-full p-3 bg-lime-50 border border-amber-200 rounded-xl text-lg font-bold text-lime-900 focus:ring-2 focus:ring-lime-500 focus:border-transparent outline-none transition-all placeholder:text-amber-300" %>
-        </div>
-        <%= f.submit '家族メンバーになる', class: "w-full py-3 bg-lime-500 hover:bg-lime-600 text-white font-bold rounded-full shadow-md transition-all active:scale-95 cursor-pointer" %>
-      <% end %>
-    </div>
-    -->
-
     <div class="bg-white border border-amber-200 rounded-3xl py-6 px-4 flex flex-col shadow-sm">
         <div class="flex items-center mb-4">
           <span class="icon-[bi--house-add-fill] text-xl text-amber-600 mx-2"></span>

--- a/app/views/families/families/new.html.erb
+++ b/app/views/families/families/new.html.erb
@@ -39,7 +39,7 @@
         <div class="h-px bg-amber-300 flex-grow"></div>
       </div>
       
-      <div class="bg-white rounded-3xl shadow-xl p-7 border border-amber-200">
+      <div class="bg-white rounded-3xl shadow-md p-7 border border-amber-200">
         <div class="flex items-center mb-6">
           <span class="icon-[material-symbols--family-group-rounded] text-2xl text-amber-600 mr-2"></span>
           <h2 class="text-xl font-bold text-amber-900">新しく家族を作成</h2>

--- a/app/views/families/families/new.html.erb
+++ b/app/views/families/families/new.html.erb
@@ -1,41 +1,66 @@
-<div id="new_family" class="text-center">
-  <h1 class="text-3xl font-bold m-6">家族（グループ）の作成</h1>
+<div class="min-h-full bg-lime-100 flex flex-col items-center py-10 px-4 sm:px-6 lg:px-8">
+  <h1 class="text-2xl font-extrabold text-lime-900 text-center mb-8">家族（グループ）への参加／作成</h1>
+  
+  <div class="w-full max-w-md space-y-6">
+    <div class="bg-amber-50 border border-amber-200 rounded-2xl p-4 flex items-center shadow-sm">
+      <span class="icon-[mdi--information-outline] text-2xl text-amber-600 mr-3"></span>
+      <p class="text-amber-900 font-semibold text-sm"> <%= t('helpers.message.not_a_member_of_family') %> </p>
+    </div>
 
-  <div id="not_belongs_family" class="my-8">
-    <div>
-      あなたは家族（グループ）に所属していません
+    <!--
+    <div class="bg-white rounded-3xl shadow-xl p-7 border border-amber-200">
+      <div class="flex items-center mb-6"> <span class="icon-[mdi--link-variant] text-2xl text-amber-600 mr-2"></span>
+        <h2 class="text-xl font-bold text-amber-900">家族に参加する</h2>
+      </div>
+      
+      <%= form_with url: root_path, data: { method: :get }, local: true, class: "space-y-5" do |f| %>
+        <div class="space-y-2">
+          <%= f.label :code, '共有された家族コード', class: "block text-sm font-bold text-amber-800 ml-1" %>
+          <%= f.text_field :code, class: "w-full p-3 bg-lime-50 border border-amber-200 rounded-xl text-lg font-bold text-lime-900 focus:ring-2 focus:ring-lime-500 focus:border-transparent outline-none transition-all placeholder:text-amber-300" %>
+        </div>
+        <%= f.submit '家族メンバーになる', class: "w-full py-3 bg-lime-500 hover:bg-lime-600 text-white font-bold rounded-full shadow-md transition-all active:scale-95 cursor-pointer" %>
+      <% end %>
+    </div>
+    -->
+
+    <div class="bg-white border border-amber-200 rounded-3xl py-6 px-4 flex flex-col shadow-sm">
+        <div class="flex items-center mb-4">
+          <span class="icon-[bi--house-add-fill] text-xl text-amber-600 mx-2"></span>
+          <h2 class="text-xl font-bold text-amber-900 mr-2">既にある家族（グループ）に参加</h2>
+        </div>
+      <div class="bg-rose-100 rounded-2xl">
+        <p class="text-rose-600 font-medium text-sm p-4"> <%= t('helpers.message.need_to_apply_for_be_family') %> </p>
+      </div>
+    </div>
+    
+    <div class="flex items-center justify-center space-x-4">
+      <div class="h-px bg-amber-300 flex-grow"></div>
+        <span class="text-amber-600 font-bold text-sm">または</span>
+        <div class="h-px bg-amber-300 flex-grow"></div>
+      </div>
+      
+      <div class="bg-white rounded-3xl shadow-xl p-7 border border-amber-200">
+        <div class="flex items-center mb-6">
+          <span class="icon-[material-symbols--family-group-rounded] text-2xl text-amber-600 mr-2"></span>
+          <h2 class="text-xl font-bold text-amber-900">新しく家族を作成</h2>
+        </div>
+        
+        <%= form_with(model: @family, url: families_path, data: { turbo: false }, local: true, class: "space-y-5") do |f| %>
+          <div class="space-y-2">
+            <%= f.label :name, t('activerecord.attributes.family.name'), class: "block text-sm font-bold text-amber-800 ml-1" %>
+            <%= f.text_field :name, class: "w-full p-3 bg-lime-50 border border-amber-300 rounded-xl text-md font-bold text-lime-900 focus:ring-2 focus:ring-lime-500 focus:border-transparent outline-none transition-all placeholder:text-lime-400", placeholder: "家族（グループ）名を入力してください" %>
+          </div>
+          <%= f.submit t('helpers.submit.family.create'), data: { turbo: false }, class: "w-full py-3 bg-amber-500 hover:bg-amber-600 text-white font-bold rounded-full shadow-md transition-all active:scale-95 cursor-pointer" %>
+        <% end %>
+      </div>
+    <div class="text-center pt-2">
+      <%= link_to mypage_path, class: "inline-flex items-center text-lime-900 font-bold hover:text-amber-700 transition-colors" do %>
+        <span class="icon-[mdi--arrow-left] mr-1"></span> <%= t('helpers.link.back_to_mypage') %>
+      <% end %>
     </div>
   </div>
+</div>
 
-  <div id="family_code_form" class="my-10">
-    <%= form_with url: root_path, data: { turbo: false }, local: true do |f| %>
-      <div>
-        <%= f.label :code, '家族コードを入力' %>
-      </div>
-      <div>
-        <%= f.text_field :code, class: "border border-default-medium rounded-base" %>
-      </div>
-      <div>
-        <%= f.submit '家族（グループ）メンバーになる', class: "box-border border border-default-medium shadow-xs font-medium rounded-full text-sm px-4 py-2 m-2" %>
-      </div>
-    <% end %>
-  </div>
-
-  <div id="create_family_form" class="my-10">
-    <%= form_with(model: @family, url: families_path, data: { turbo: false }, local: true) do |f| %>
-      <div>
-        <%= f.label :name, "家族（グループ）名" %>
-      </div>
-      <div>
-        <%= f.text_field :name, class: "border border-default-medium rounded-base" %>
-      </div>
-      <div>
-        <%= f.submit "家族（グループ）を作成", data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium rounded-full text-sm px-4 py-2 m-2" %>
-      </div>
-    <% end %>
-  </div>
-
-  <div>
-    <%= render 'layouts/footer' %>
-  </div>
+<div>
+  <%= render 'layouts/footer' %>
 </div>

--- a/app/views/families/families/show.html.erb
+++ b/app/views/families/families/show.html.erb
@@ -33,20 +33,21 @@
       </div>
       <ul class="space-y-3 mb-4">
         <% @members.each do |member| %>
-          <li class="flex items-center justify-between bg-amber-100/50 rounded-2xl p-3 shadow-sm">
-            <div class="flex items-center">
-              <div class="size-10 rounded-full flex items-center justify-center mr-3 shadow-inner">
-                <%= image_tag member.display_avatar, class: "rounded-full" %>
+          <li class="w-full flex flex-wrap items-center justify-between bg-amber-100/50 rounded-2xl p-3 shadow-sm">
+            <div class="w-full flex items-center">
+              <div class="size-10 rounded-full flex flex-none items-center justify-center mr-3 shadow-inner overflow-hidden">
+                <%= image_tag member.display_avatar, class: "w-full h-full object-cover" %>
               </div>
-              <div>
-                <span class="<%= member.id == current_user.id ? "bg-rose-200/70 font-semibold text-md text-amber-900" : "font-semibold text-md text-amber-900" %>"><%= member.name %></span>
+              <div class="text-wrap">
+                <span class="<%= current_user.id == member.id ? "bg-rose-200 font-semibold text-md text-amber-900" : "font-semibold text-md text-amber-900" %>"><%= member.name %></span>
               </div>
+              <% if member.id == @family.owner_id %>
+                <div class="flex flex-nowrap items-center ml-auto text-xs font-medium text-lime-900 bg-lime-300/70 px-2 py-1 rounded-full">
+                  <span class="icon-[mdi--shield-check] mr-1"></span>
+                  <span class="text-nowrap"><%= t('activerecord.attributes.family.owner') %></span>
+                </div>
+              <% end %>
             </div>
-            <% if member.id == @family.owner_id %>
-              <span class="flex items-center text-xs font-medium text-lime-900 bg-lime-300/70 px-2 py-1 rounded-full">
-                <span class="icon-[mdi--shield-check] mr-1"></span><%= t('activerecord.attributes.family.owner') %>
-              </span>
-            <% end %>
           </li>
         <% end %>
       </ul>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -104,7 +104,9 @@ ja:
         submit: ログイン
         update: 更新する
       family:
+        create: 家族を作成する
         update: 家族名を更新する
+        destroy: 家族を削除する
       password:
         create: 再設定メールを送信
         update: パスワードを更新する
@@ -112,6 +114,8 @@ ja:
       no_diary_found: 該当する日記はありません
       no_diary_on_day: この日の日記はありません
       no_children_data: 子どもの情報が登録されていません
+      not_a_member_of_family: 現在、あなたは家族に所属していません。
+      need_to_apply_for_be_family: 家族（グループ）の管理ユーザーにメールアドレスを伝え、メンバーに追加してもらいましょう。
     button:
       family:
         add_member: メンバーを追加


### PR DESCRIPTION
## 概要
家族を作成するページのデザインを整える

## 関連issue
#120 

## やったこと
 - `families/families/new`のUIデザインを一新
 - `families/families/show` と `families/families/show` の「家族メンバー表示部分」を調整

## やらないこと
 - 作成した家族を削除する機能を実装

## テスト／完了確認
 - [x] 家族作成ページがモバイル端末に最適化されたデザインになっていることを確認
 - [x] 家族の新規作成が問題なくできることを確認

## 備考
ユーザーが誤って家族情報を作成・登録してしまった場合のことを考え、家族を削除する機能をMVPリリース前に実装したい