### PR TITLE
Feature/#122 家族メンバーを一覧表示する画面のデザインを整える

### DIFF
--- a/app/controllers/families/families_controller.rb
+++ b/app/controllers/families/families_controller.rb
@@ -54,7 +54,7 @@ module Families
     # オーナー以外は編集できないようにする
     def authorize_owner
       if current_user.family.present?
-        unless @family.owner.id == current_user.id
+        unless @family.owner_id == current_user.id
           redirect_to root_path, alert: '編集権限がありません。'
         end
       else

--- a/app/controllers/families/families_controller.rb
+++ b/app/controllers/families/families_controller.rb
@@ -54,7 +54,7 @@ module Families
     # オーナー以外は編集できないようにする
     def authorize_owner
       if current_user.family.present?
-        unless @family.owner_id == current_user.id
+        unless @family.owner.id == current_user.id
           redirect_to root_path, alert: '編集権限がありません。'
         end
       else

--- a/app/helpers/families/members_helper.rb
+++ b/app/helpers/families/members_helper.rb
@@ -1,9 +1,9 @@
 module Families::MembersHelper
-  def delete_or_optout(user, family)
-    if user.id == family.owner_id
-      "削除する"
-    else
+  def delete_or_optout(user)
+    if user.id == current_user.id
       "脱退する"
+    else
+      "削除する"
     end
   end
 end

--- a/app/views/families/families/show.html.erb
+++ b/app/views/families/families/show.html.erb
@@ -26,7 +26,16 @@
           <h2 class="text-md font-bold text-amber-800"><%= t('activerecord.attributes.family.members') %></h2>
         </div>
         <% if current_user.id == @family.owner_id %>
-          <%= link_to edit_family_path, class: "size-8 text-rose-600 p-2 bg-rose-100 rounded-full shadow-sm" do %>
+          <div class="ml-auto flex gap-2">
+            <%= link_to edit_family_path, class: "size-8 text-rose-600 p-2 bg-rose-100 rounded-full shadow-sm" do %>
+              <span class="icon-[mdi--user-edit] text-xl"></span>
+            <% end %>
+            <%= link_to family_members_path(@family), class: "size-8 text-rose-600 p-2 bg-rose-100 rounded-full shadow-sm" do %>
+              <span class="icon-[tdesign--user-clear] text-xl"></span>
+            <% end %>
+          </div>
+        <% else %>
+          <%= link_to family_members_path(@family), class: "size-8 text-rose-600 p-2 bg-rose-100 rounded-full shadow-sm" do %>
             <span class="icon-[mdi--user-edit] text-xl"></span>
           <% end %>
         <% end %>

--- a/app/views/families/members/index.html.erb
+++ b/app/views/families/members/index.html.erb
@@ -1,33 +1,51 @@
-<div id="new_member" class="text-center">
-  <h1 class="text-3xl font-bold m-6">家族メンバー一覧</h1>
-
-  <div class="flex justify-center my-10">
-    <table>
+<div class="min-h-full bg-lime-100 flex flex-col items-center py-8 px-4 sm:px-6 lg:px-8">
+  <div class="w-full max-w-md space-y-6">
+    <div class="text-center mb-6">
+      <h1 class="text-2xl font-extrabold text-lime-900">家族メンバーの管理</h1>
+      <p class="text-sm text-amber-800 mt-2">メンバーの確認と削除</p>
+    </div>
+    
+    <div class="space-y-4">
     <% @members.each do |member| %>
-      <tr>
-        <td>
-          <%= member.name %>：
-          <%= member.email %>
-        </td>
-        <td>
-          <% if @family.owner_id == current_user.id || member.id == current_user.id %>
-            <%= button_to delete_or_optout(current_user, @family),
-                  family_member_path(@family, member),
-                  method: :delete,
-                  data: { turbo_confirm: "本当にこのメンバーを家族から削除しますか？" },
-                  class: "box-border border border-default-medium shadow-xs font-medium rounded-full text-sm px-4 py-2 m-2" %>
+      <div class="bg-white rounded-3xl shadow-md p-5 border border-amber-200">
+        <div class="flex items-center justify-between mb-4">
+          <div class="flex items-center min-w-0">
+            <div class="size-12 rounded-full bg-lime-100 flex items-center justify-center mr-4 shadow-inner flex-shrink-0 overflow-hidden border-2 border-white">
+              <%= image_tag member.display_avatar, class: "w-full h-full object-cover" %>
+            </div>
+            
+            <div class="truncate">
+              <div class="flex items-center gap-2">
+                <span class="font-bold text-amber-900 truncate">
+                  <%= member.name %>
+                </span>
+                <% if member.id == current_user.id %>
+                  <span class="text-[10px] bg-amber-200 text-amber-800 px-2 py-0.5 rounded-full font-bold whitespace-nowrap">あなた</span>
+                <% end %>
+              </div>
+              <p class="text-xs text-amber-600 truncate"><%= member.email %></p>
+            </div>
+          </div>
+          
+          <% if member.id == @family.owner_id %>
+            <span class="flex-shrink-0 flex items-center text-xs font-bold text-lime-800 bg-lime-200 px-2 py-1 rounded-full ml-2"> <span class="icon-[mdi--shield-check] mr-1"></span><%= t('activerecord.attributes.family.owner') %></span>
           <% end %>
-        </td>
-      </tr>
+        </div>
+        
+        <% if @family.owner_id == current_user.id || member.id == current_user.id %>
+          <div class="pt-3 border-t border-amber-50">
+            <%= button_to family_member_path(@family, member), method: :delete, data: { turbo_confirm: "本当にこのメンバーを家族から削除しますか？" }, class: "w-full py-2.5 bg-white border-2 border-rose-400 text-rose-500 hover:bg-rose-50 font-bold rounded-full text-sm transition-all active:scale-95 flex items-center justify-center cursor-pointer" do %> <span class="icon-[mdi--account-remove-outline] mr-2 text-lg"></span>
+              <%= delete_or_optout(member) %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
     <% end %>
-    </table>
-  </div>
-
-  <div class="my-8">
-    <%= link_to "戻る", family_path(@family), data: { turbo: false } %>
-  </div>
-
-  <div>
-    <%= render 'layouts/footer' %>
+    </div>
+    
+    <div class="text-center pt-6">
+      <%= link_to family_path(@family), data: { turbo: false }, class: "inline-flex items-center text-lime-900 font-bold hover:text-amber-700 transition-colors" do %> <span class="icon-[mdi--arrow-left] mr-1"></span> <%= t('helpers.link.back_to_family_page') %>
+      <% end %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## 概要
家族メンバー一覧表示画面のデザインを整える

## 関連issue
#122 

## やったこと
 - `families/member/index`ページのUIを整えた
 - `app/helpers/families/members_helper.rb`の`delete_or_optout`メソッドを修正
 - `families/families/show`から、家族の管理ユーザーであるかどうかを問わずに`families/member/index`ページにアクセスできるようにした

## やらないこと
 - 

## テスト／完了確認
 - [x] 家族メンバーを一覧表示する画面がスマートフォンに最適化されたデザインになっていることを確認
 - [x] 「脱退する」「削除する」のボタン表示が適切であることを確認
 - [x] 家族メンバーの削除が問題なくできることを確認
 - [x] 家族からの脱退が問題なくできることを確認