### PR TITLE
Feature/#124 子どもを一覧表示する、編集するページのデザインを整える

### DIFF
--- a/app/views/families/children/edit.html.erb
+++ b/app/views/families/children/edit.html.erb
@@ -1,32 +1,34 @@
-<div id="edit_child" class="text-center">
-  <h1 class="text-3xl font-bold m-6">子供の情報を編集</h1>
-  <div class="my-10">
-    <%= form_with(model: [@family, @child], data: { turbo: false }) do |f| %>
-      <div>
-        <%= f.label :name, "名前" %>
-      </div>
-      <div>
-        <%= f.text_field :name, class: "border border-default-medium rounded-base" %>
-      </div>
-
-      <div>
-        <%= f.label :birthday, "誕生日" %>
-      </div>
-      <div>
-        <%= f.date_field :birthday, class: "border border-default-medium rounded-base" %>
-      </div>
-
-      <div>
-        <%= f.submit "更新する", data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium rounded-full text-sm px-4 py-2 m-2" %>
-      </div>
-    <% end %>
-  </div>
-
-  <div>
-    <%= link_to "キャンセル", family_path(@family), data: { turbo: false } %>
-  </div>
-
-  <div>
-    <%= render 'layouts/footer' %>
+<div class="h-full bg-lime-100 flex flex-col items-center py-8 px-4 sm:px-6 lg:px-8">
+  <div class="w-full max-w-md space-y-6">
+    <h1 class="text-2xl justify-self-center font-extrabold text-lime-900">子どもの情報を編集</h1>
+    
+    <div class="bg-white rounded-3xl shadow-md p-7 border border-amber-200">
+      <%= form_with(model: [@family, @child], data: { turbo: false }, class: "space-y-6") do |f| %>
+        <div class="space-y-2">
+          <div class="flex items-center ml-1">
+            <span class="icon-[cil--child] text-xl text-amber-600 mr-2"></span>
+            <%= f.label :name, t('activerecord.attributes.child.name'), class: "font-bold text-amber-900" %>
+          </div>
+            <%= f.text_field :name, class: "w-full p-3 bg-lime-50 border border-amber-200 rounded-xl text-lg font-medium text-lime-900 focus:ring-2 focus:ring-lime-500 focus:border-transparent outline-none transition-all placeholder:text-amber-300", placeholder: "例：はなこ" %>
+          </div>
+          
+          <div class="space-y-2">
+            <div class="flex items-center ml-1">
+              <span class="icon-[mdi--cake-variant-outline] text-xl text-amber-600 mr-2"></span>
+              <%= f.label :birthday, t('activerecord.attributes.child.birthday'), class: "font-bold text-amber-900" %>
+            </div>
+            <%= f.date_field :birthday, class: "w-full p-3 bg-lime-50 border border-amber-200 rounded-xl text-lg font-medium text-lime-900 focus:ring-2 focus:ring-lime-500 focus:border-transparent outline-none transition-all", placeholder: "誕生日を選択" %>
+          </div>
+            
+          <div class="pt-4">
+            <%= f.submit t('helpers.submit.children.update'), data: { turbo: false }, class: "w-full py-4 bg-amber-500 hover:bg-amber-600 text-white font-bold rounded-full shadow-lg transition-all active:scale-95 cursor-pointer flex items-center justify-center text-lg" %>
+          </div>
+      <% end %>
+        </div>
+        
+    <div class="text-center pt-4">
+      <%= link_to family_children_path, data: { turbo: false }, class: "inline-flex items-center text-lime-900 font-bold hover:text-amber-700 transition-colors" do %> <span class="icon-[mdi--arrow-left] mr-1"></span> <%= t('helpers.link.back_to_children_page') %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/families/children/index.html.erb
+++ b/app/views/families/children/index.html.erb
@@ -1,36 +1,51 @@
-<div id="index_children" class="text-center">
-  <h1 class="text-3xl font-bold m-6">子どもの情報一覧</h1>
+<div class="min-h-full bg-lime-100 flex flex-col items-center py-8 px-4 sm:px-6 lg:px-8">
+  <div class="w-full max-w-md space-y-6">
+    <div class="text-center mb-4">
+      <h1 class="text-2xl font-extrabold text-lime-900">子どもの情報一覧</h1>
+    </div>
+    
+    <div class="space-y-4">
+      <% @children.each do |child| %>
+        <div class="bg-amber-50 rounded-2xl shadow-md p-4 border border-amber-200">
+          <div class="flex items-center justify-between px-1">
+            <div class="flex items-center">
+              <span class="icon-[fa-regular--smile] mr-2 text-xl text-amber-600"></span>
+              <h2 class="text-xl font-bold text-amber-900 truncate mr-4"><%= child.name %></h2>
+            </div>
+            <div class="flex items-center text-amber-700 text-md flex-shrink-0">
+              <span class="icon-[mdi--cake-variant] mr-1"></span>
+              <span class="font-medium"><%= child.birthday %></span>
+            </div>
+          </div>
 
-  <div class="flex justify-center my-10">
-    <table>
-    <% @children.each do |child| %>
-      <tr>
-        <td>
-          <%= child.name %>：
-          <%= child.birthday %>
-        </td>
-        <td>
           <% if @family.owner_id == current_user.id %>
-            <%= button_to "編集", edit_family_child_path(@family, child), method: :get, data: { turbo: false }, class: "box-border border border-default-medium shadow-xs font-medium rounded-full text-sm px-4 py-2 m-2" %>
-        </td>
-        <td>
-            <%= button_to "削除",
-                  family_child_path(@family, child),
-                  method: :delete,
-                  data: { turbo_confirm: "本当にこの子どもの情報を家族から削除しますか？" },
-                  class: "box-border border border-default-medium shadow-xs font-medium rounded-full text-sm px-4 py-2 m-2" %>
+            <div class="flex items-center gap-2 pt-4 border-t border-amber-50">
+              <%= link_to edit_family_child_path(@family, child), data: { turbo: false }, class: "flex-2 py-2 bg-lime-500 hover:bg-lime-600 text-white font-bold rounded-full text-sm shadow-sm transition-all active:scale-95 flex items-center justify-center min-w-0" do %>
+                <span class="icon-[mdi--pencil-outline] mr-2 text-lg"></span>
+                <span><%= t('helpers.button.edit') %></span>
+              <% end %>
+              <%= button_to family_child_path(@family, child), method: :delete, data: { turbo_confirm: "本当にこの子どもの情報を家族から削除しますか？" }, form_class: "flex-1", class: "w-full py-2 bg-rose-400 hover:bg-rose-500 text-rose-50 font-bold rounded-full text-sm shadow-sm transition-all active:scale-95 flex items-center justify-center cursor-pointer min-w-0" do %>
+                <span class="icon-[mdi--trash-can-outline] mr-2 text-lg"></span>
+                <span><%= t('helpers.button.delete') %></span>
+              <% end %>
+            </div>
           <% end %>
-        </td>
-      </tr>
+        </div>
+      <% end %>
+    </div>
+    
+    <% if @family.owner_id == current_user.id %>
+      <div>
+        <%= link_to new_family_child_path(@family), data: { turbo: false }, class: "flex items-center justify-center w-full py-4 bg-amber-100/70 border-2 border-dashed border-amber-300 text-amber-800 font-bold rounded-3xl hover:bg-amber-50 transition-colors" do %>
+          <span class="icon-[mdi--plus-circle-outline] mr-2 text-xl"></span> <%= t('helpers.button.children.add_new_child') %>
+        <% end %>
+      </div>
     <% end %>
-    </table>
-  </div>
-
-  <div>
-    <%= link_to "戻る", family_path(@family), data: { turbo: false } %>
-  </div>
-
-  <div>
-    <%= render 'layouts/footer' %>
+    
+    <div class="text-center pt-6">
+      <%= link_to family_path(@family), data: { turbo: false }, class: "inline-flex items-center text-lime-900 font-bold hover:text-amber-700 transition-colors" do %>
+        <span class="icon-[mdi--arrow-left] mr-1"></span> <%= t('helpers.link.back_to_family_page') %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/families/children/new.html.erb
+++ b/app/views/families/children/new.html.erb
@@ -27,7 +27,7 @@
         </div>
         
     <div class="text-center pt-4">
-      <%= link_to family_path(@family), data: { turbo: false }, class: "inline-flex items-center text-lime-900 font-bold hover:text-amber-700 transition-colors" do %> <span class="icon-[mdi--arrow-left] mr-1"></span> <%= t('helpers.link.back_to_family_page') %>
+      <%= link_to edit_family_path(@family), data: { turbo: false }, class: "inline-flex items-center text-lime-900 font-bold hover:text-amber-700 transition-colors" do %> <span class="icon-[mdi--arrow-left] mr-1"></span> <%= t('helpers.link.back_to_family_page') %>
       <% end %>
     </div>
   </div>

--- a/app/views/families/families/show.html.erb
+++ b/app/views/families/families/show.html.erb
@@ -62,7 +62,7 @@
       </ul>
     </div>
 
-    <div class="bg-white rounded-2xl shadow-md p-6 border border-amber-200">
+    <div class="bg-white rounded-2xl shadow-md px-6 py-4 border border-amber-200">
       <div class="flex items-center justify-between mb-4">
         <div class="flex items-center">
           <span class="icon-[mdi--baby-face-outline] text-2xl text-amber-600 mr-2"></span>
@@ -75,7 +75,7 @@
         <% end %>
       </div>
       <% if @family.children.any? %>
-        <ul class="grid grid-cols-2 gap-3 mb-4">
+        <ul class="grid grid-cols-2 gap-3 mb-2">
           <% @family.children.each do |child| %>
             <li class="bg-amber-50 rounded-2xl p-4 text-center border border-amber-100 shadow-sm">
               <span class="font-extrabold text-amber-900"><%= child.name %></span>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -111,6 +111,7 @@ ja:
         create: 家族に招待する
       children:
         create: 登録する
+        update: 更新する
       password:
         create: 再設定メールを送信
         update: パスワードを更新する
@@ -127,7 +128,10 @@ ja:
         optout_family: 家族から脱退
       children:
         add_child: 子どもの情報を追加
+        add_new_child: 新しい子どもの情報を追加
         edit_children: 子どもの情報を編集・削除
+      edit: 編集
+      delete: 削除
     link:
       signup: 新規登録
       login: ログイン
@@ -139,6 +143,7 @@ ja:
       forget_password: パスワードをお忘れですか？
       back_to_mypage: マイページに戻る
       back_to_family_page: 家族の情報に戻る
+      back_to_children_page: 子どもの情報一覧に戻る
   views:
     pagination:
       first: "&laquo;"


### PR DESCRIPTION
## 概要
子どもの情報を一覧表示する、編集するページのデザインを整える

## 関連issue
#124 

## やったこと
 - `families/children/index`ページのデザインを一新
 - `families/children/edit`ページのデザインを`families/children/new`と同じものにした
 - `families/children/new`ページの戻るリンクのパスを `edit_family_path` に変更
 - `config/locales/ja.yml`に、上記ページに使用するボタンやリンクの項目を追加

## やらないこと
 - 

## テスト／完了確認
 - [x] 子どもの情報を一覧表示する画面がスマートフォンに最適化されたデザインになっていることを確認
 - [x] 子どもの情報を編集する画面がスマートフォンに最適化されたデザインになっていることを確認
 - [x] 子どもの情報を編集（更新）、削除できることを確認