### PR TITLE
Feature/#125 家族を削除する機能を実装

### DIFF
--- a/app/controllers/families/families_controller.rb
+++ b/app/controllers/families/families_controller.rb
@@ -1,11 +1,10 @@
 module Families
   class FamiliesController < ApplicationController
     before_action :authenticate_user!
-    before_action :set_family, only: [:edit, :update]
-    before_action :authorize_owner, only: [:edit, :update]
+    before_action :set_family, only: [:edit, :update, :destroy]
+    before_action :authorize_owner, only: [:edit, :update, :destroy]
 
     def new
-      # すでに家族に所属している、またはオーナーである場合は作成画面に行かせない
       unless current_user.can_create_family?
         return redirect_to root_path, alert: "すでに家族に所属しているため、新しく作成することはできません。"
       end
@@ -43,6 +42,29 @@ module Families
         # バリデーションエラー時は編集画面を再表示
         render :edit, status: :unprocessable_entity
       end
+    end
+
+    def destroy
+      # 条件1：家族のメンバーが自分（管理者）以外にいないこと
+      if @family.users.count > 1
+        return redirect_to family_path(@family), alert: '自分以外のメンバーがいる場合は家族を削除できません。'
+      end
+
+      # 条件2：子どもの情報が一つも存在していないこと
+      if @family.children.count > 0
+        return redirect_to family_path(@family), alert: '子どもの情報がある場合は家族を削除できません。'
+      end
+
+      ActiveRecord::Base.transaction do
+        # 1. ユーザーの family_id を空にする
+        current_user.update!(family_id: nil)
+        # 2. 家族レコードを削除
+        @family.destroy!
+      end
+
+      redirect_to root_path, notice: '家族を削除しました。', status: :see_other
+    rescue => e
+      redirect_to family_path(@family), alert: '家族の削除に失敗しました。'
     end
 
     private

--- a/app/controllers/families/families_controller.rb
+++ b/app/controllers/families/families_controller.rb
@@ -76,7 +76,9 @@ module Families
     # オーナー以外は編集できないようにする
     def authorize_owner
       if current_user.family.present?
-        unless @family.owner_id == current_user.id
+        if @family.nil?
+          redirect_to root_path, alert: '家族（グループ）の情報を取得できませんでした。'
+        elsif @family.owner_id != current_user.id
           redirect_to root_path, alert: '編集権限がありません。'
         end
       else

--- a/app/views/families/families/edit.html.erb
+++ b/app/views/families/families/edit.html.erb
@@ -88,13 +88,11 @@
         </div>
       </div>
 
-    <!--
     <div class="space-y-3">
       <%= button_to family_path(family_id: @family.id), method: :delete, data: { turbo_confirm: "本当にこの家族を削除しますか？" }, class: "flex items-center justify-center w-full py-3 bg-rose-500/80 hover:bg-rose-600/80 text-white font-bold rounded-full shadow-md transition-all active:scale-95" do %>
         <span class="icon-[mdi--house-off] mr-2 text-lg"></span><%= t('helpers.submit.family.destroy') %>
       <% end %>
     </div>
-    -->
       
     <div class="pt-4 text-center">
       <%= link_to family_path(@family), data: { turbo: false }, class: "inline-flex items-center text-lime-900 font-bold hover:text-amber-700 transition-colors" do %>

--- a/app/views/mypages/edit.html.erb
+++ b/app/views/mypages/edit.html.erb
@@ -36,8 +36,14 @@
         <%= f.date_field :birthday, class: "w-full p-3 border border-amber-300 rounded-xl focus:ring-2 focus:ring-lime-500 focus:border-transparent transition duration-200 ease-in-out bg-white text-amber-800 shadow-sm" %>
       </div>
       
-      <div class="py-4 text-center">
-        <%= f.submit t('helpers.submit.user.update'), data: { turbo: false }, class: "w-full bg-lime-600 hover:bg-lime-700 text-white font-bold py-3 px-6 rounded-full shadow-md transition duration-300 ease-in-out transform hover:scale-105 cursor-pointer" %>
+      <div class="text-center">
+        <div class="flex flex-col gap-4">
+          <%= f.submit t('helpers.submit.user.update'), data: { turbo: false }, class: "w-full bg-lime-600 hover:bg-lime-700 text-white font-bold py-3 px-6 rounded-full shadow-sm transition duration-300 ease-in-out transform hover:scale-105 cursor-pointer" %>
+
+          <%= link_to edit_password_path, data: { turbo: false }, class: "w-full bg-amber-500 hover:bg-amber-700 text-white font-bold py-3 px-6 rounded-full shadow-sm transition duration-300 ease-in-out transform hover:scale-105 cursor-pointer" do %>
+            <span><%= t('helpers.button.mypages.edit_password') %></span>
+          <% end %>
+        </div>
       </div>
     <% end %>
     </div>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -17,6 +17,10 @@
       <%= f.submit t('helpers.submit.password.update'), class: "w-full bg-rose-500 hover:bg-rose-600 text-white font-bold py-3 px-6 rounded-full shadow-lg transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-opacity-50 tracking-wide mt-2" %>
     <% end %>
   </div>
+
+  <div class="text-center my-8">
+    <%= link_to t('helpers.link.back_to_mypage'), mypage_path, data: { turbo: false }, class: "inline-flex items-center text-amber-900 font-medium hover:text-lime-600 transition-colors duration-200" %>
+  </div>
 </div>
 
 <script>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -122,6 +122,8 @@ ja:
       not_a_member_of_family: 現在、あなたは家族に所属していません。
       need_to_apply_for_be_family: 家族（グループ）の管理ユーザーにメールアドレスを伝え、メンバーに追加してもらいましょう。
     button:
+      mypages:
+        edit_password: パスワードを変更する
       family:
         add_member: メンバーを追加
         delete_member: メンバーを削除


### PR DESCRIPTION
## 概要
家族を削除する機能を実装

## 関連issue
#125 

## やったこと
 - `app/controllers/families/families_controller.rb`に`destroy`アクションを追加
 - さらに `authorize_owner` メソッドの条件式を修正
 - `families/families/edit`ページに「家族を削除する」ボタンを追加
 - `mypages/edit`ページにパスワード変更ページへの導線を追加

## やらないこと
 - 

## テスト／完了確認
 - [x] 家族が正常に削除できることを確認
	 - [x] 家族を削除したら、ユーザー情報の`family_id`が空になることを確認
	 - [x] 条件を満たしていない場合は、家族が削除できないことを確認