### PR TITLE
Feature/#126 各ページにタイトルを設定

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,4 +7,10 @@ module ApplicationHelper
     else "bg-gray-100 border border-gray-400 text-gray-700"
     end
   end
+
+  def page_title(title)
+    base_title = 'おもいでつむぎ'
+
+    title.empty? ? base_title : title + " | " +  base_title
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,6 +11,6 @@ module ApplicationHelper
   def page_title(title)
     base_title = 'おもいでつむぎ'
 
-    title.empty? ? base_title : title + " | " +  base_title
+    title.blank? ? base_title : title + " | " +  base_title
   end
 end

--- a/app/views/auth/login.html.erb
+++ b/app/views/auth/login.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, t('.title')) %>
+
 <div class="min-h-full bg-lime-50 flex flex-col justify-center items-center py-4 px-4 sm:px-6 lg:px-8">
   <h2 class="text-3xl font-extrabold text-lime-800 text-center mb-4">ログイン</h2>
 

--- a/app/views/auth/signup.html.erb
+++ b/app/views/auth/signup.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, t('.title')) %>
+
 <div class="min-h-full bg-lime-50 flex flex-col justify-center items-center py-4 px-4 sm:px-6 lg:px-8">
   <h2 class="text-3xl font-extrabold text-lime-900 text-center mb-4">ユーザー登録</h2>
 

--- a/app/views/diaries/date_index.html.erb
+++ b/app/views/diaries/date_index.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, "#{l(@date.to_date, format: :long)}の日記") %>
+
 <div id="date_index" class="min-h-full bg-lime-50">
   <div class="px-4 py-4">
     <h1 class="text-2xl font-bold text-amber-900 text-center mb-4">

--- a/app/views/diaries/edit.html.erb
+++ b/app/views/diaries/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, t('.title')) %>
+
 <div class="min-h-full bg-lime-50 flex flex-col items-center py-3 px-4 sm:px-6 lg:px-8">
   <!-- Container -->
   <div class="w-full max-w-md p-2 space-y-2">

--- a/app/views/diaries/filter.html.erb
+++ b/app/views/diaries/filter.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, t('.title')) %>
+
 <div id="filter_diaries" class="min-h-full bg-lime-50 pb-20">
   <div class="px-4 py-4">
     <h1 class="text-2xl font-bold text-amber-900 text-center mb-4">日記を絞り込む</h1>

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, t('.title')) %>
+
 <div id="diary_index" class="bg-amber-50 min-h-full">
   <div class="max-w-4xl mx-auto">
     <div id="diary_calendar" class="w-full">

--- a/app/views/diaries/new.html.erb
+++ b/app/views/diaries/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, t('.title')) %>
+
 <div class="min-h-full bg-lime-50 flex flex-col items-center py-3 px-4 sm:px-6 lg:px-8">
   <!-- Container -->
   <div class="w-full max-w-md p-2 space-y-4">

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, t('.title')) %>
+
 <div id="diary_show" class="min-h-full bg-amber-100/70 py-4 px-4">
   <h1 class="text-center text-3xl font-bold text-amber-900 mb-4">日記の詳細</h1>
 

--- a/app/views/families/children/edit.html.erb
+++ b/app/views/families/children/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, t('.title')) %>
+
 <div class="h-full bg-lime-100 flex flex-col items-center py-8 px-4 sm:px-6 lg:px-8">
   <div class="w-full max-w-md space-y-6">
     <h1 class="text-2xl justify-self-center font-extrabold text-lime-900">子どもの情報を編集</h1>

--- a/app/views/families/children/index.html.erb
+++ b/app/views/families/children/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, t('.title')) %>
+
 <div class="min-h-full bg-lime-100 flex flex-col items-center py-8 px-4 sm:px-6 lg:px-8">
   <div class="w-full max-w-md space-y-6">
     <div class="text-center mb-4">

--- a/app/views/families/children/new.html.erb
+++ b/app/views/families/children/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, t('.title')) %>
+
 <div class="h-full bg-lime-100 flex flex-col items-center py-10 px-4 sm:px-6 lg:px-8">
   <div class="w-full max-w-md space-y-6">
     <h1 class="text-2xl justify-self-center font-extrabold text-lime-900">子どもの情報を新規登録</h1>

--- a/app/views/families/families/edit.html.erb
+++ b/app/views/families/families/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, t('.title')) %>
+
 <div class="min-h-full bg-lime-100 flex flex-col items-center py-8 px-4 sm:px-6 lg:px-8">
   <h1 class="text-2xl font-extrabold text-lime-900 text-center mb-6">家族情報の編集</h1>
 

--- a/app/views/families/families/new.html.erb
+++ b/app/views/families/families/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, t('.title')) %>
+
 <div class="min-h-full bg-lime-100 flex flex-col items-center py-10 px-4 sm:px-6 lg:px-8">
   <h1 class="text-2xl font-extrabold text-lime-900 text-center mb-8">家族（グループ）への参加／作成</h1>
   

--- a/app/views/families/families/show.html.erb
+++ b/app/views/families/families/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, t('.title')) %>
+
 <div class="min-h-full bg-lime-100 flex flex-col items-center py-8 px-4 sm:px-6 lg:px-8">
   <h1 class="text-2xl font-extrabold text-lime-900 text-center mb-6">家族の情報</h1>
   

--- a/app/views/families/members/index.html.erb
+++ b/app/views/families/members/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, t('.title')) %>
+
 <div class="min-h-full bg-lime-100 flex flex-col items-center py-8 px-4 sm:px-6 lg:px-8">
   <div class="w-full max-w-md space-y-6">
     <div class="text-center mb-6">

--- a/app/views/families/members/new.html.erb
+++ b/app/views/families/members/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, t('.title')) %>
+
 <div class="min-h-full bg-lime-100 flex flex-col items-center py-6 px-4 sm:px-6 lg:px-8">
   <div class="w-full max-w-md space-y-6">
     <h1 class="text-2xl font-extrabold text-lime-900 text-center mb-4">家族にメンバーを招待</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= page_title(yield(:title)) %></title>
+    <title><%= page_title(content_for(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="turbo-cache-control" content="no-cache">
     <%= csrf_meta_tags %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>App</title>
+    <title><%= page_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="turbo-cache-control" content="no-cache">
     <%= csrf_meta_tags %>

--- a/app/views/mypages/edit.html.erb
+++ b/app/views/mypages/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, t('.title')) %>
+
 <div class="min-h-full bg-lime-100 flex flex-col items-center pb-8 px-4 sm:px-6 lg:px-8">
   <h1 class="text-2xl font-bold text-lime-900 text-center my-4">プロフィール編集</h1>
 

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, t('.title')) %>
+
 <div class="min-h-full bg-lime-100 flex flex-col items-center py-6 px-4 sm:px-6 lg:px-8">
   <h1 class="text-2xl font-bold text-lime-900 text-center mb-4">マイページ</h1>
 

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, t('.title')) %>
+
 <div class="min-h-full bg-lime-50 flex flex-col justify-center items-center py-8 px-4 sm:px-6 lg:px-8">
   <h2 class="text-2xl font-extrabold text-lime-800 text-center mb-4">パスワードの更新</h2>
 

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, t('.title')) %>
+
 <div class="min-h-full bg-lime-50 flex flex-col justify-center items-center py-8 px-4 sm:px-6 lg:px-8">
   <h2 class="text-2xl font-extrabold text-lime-800 text-center mb-4">パスワードを再設定</h2>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -153,3 +153,19 @@ ja:
       previous: "&lsaquo;"
       next: "&rsaquo;"
       truncate: "&hellip;"
+  auth:
+    login:
+      title: ログイン
+    signup:
+      title: 新規ユーザー登録
+  diaries:
+    edit:
+      title: 日記を編集
+    filter:
+      title: 日記を絞り込む
+    index:
+      title: ホーム（カレンダー）
+    new:
+      title: 日記を投稿
+    show:
+      title: 日記の詳細

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -169,3 +169,23 @@ ja:
       title: 日記を投稿
     show:
       title: 日記の詳細
+  families:
+    children:
+      edit:
+        title: 子どもの情報を編集
+      index:
+        title: 子どもの情報一覧
+      new:
+        title: 子どもの情報を登録
+    families:
+      edit:
+        title: 家族の情報を編集
+      new:
+        title: 家族（グループ）を作成
+      show:
+        title: 家族（グループ）の情報
+    members:
+      index:
+        title: 家族のメンバー一覧
+      new:
+        title: 家族にメンバーを招待

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -189,3 +189,13 @@ ja:
         title: 家族のメンバー一覧
       new:
         title: 家族にメンバーを招待
+  mypages:
+    edit:
+      title: プロフィール編集
+    show:
+      title: マイページ
+  passwords:
+    edit:
+      title: パスワードを設定
+    new:
+      title: パスワードを再設定

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -186,7 +186,7 @@ ja:
         title: 家族（グループ）の情報
     members:
       index:
-        title: 家族のメンバー一覧
+        title: 家族のメンバー管理
       new:
         title: 家族にメンバーを招待
   mypages:


### PR DESCRIPTION
## 概要
アプリの各ページにタイトルを設定する

## 関連issue
#126

## やったこと
 - タイトルを動的に出力するためのヘルパーメソッドを定義
 - 各ページにタイトルを設定するためのコードを記述
 - `config/locales/ja.yml`に各ページのタイトルを設定

## やらないこと
 - 

## テスト／完了確認
 - [x] タイトルを設定した各ページのタイトルが適切に出力されていることを確認