### PR TITLE
Fix/#202 家族メンバーを削除（脱退）する処理の修正

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -1,7 +1,7 @@
 class DiariesController < ApplicationController
   before_action :authenticate_user!
+  before_action :check_family
   before_action :set_diary, only: [:edit, :update, :destroy]
-  before_action :check_family, only: [:index, :show, :new, :create, :edit, :update, :destroy]
 
   DIARY_COUNT = 5
 
@@ -11,7 +11,7 @@ class DiariesController < ApplicationController
 
   def show
     @diary = current_user.family.diaries.find(params[:id])
-rescue ActiveRecord::RecordNotFound
+  rescue ActiveRecord::RecordNotFound
     redirect_to diaries_path, alert: '指定された日記が見つからないか、閲覧権限がありません。'
   end
 

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -1,7 +1,7 @@
 class DiariesController < ApplicationController
   before_action :authenticate_user!
-  before_action :check_family
   before_action :set_diary, only: [:edit, :update, :destroy]
+  before_action :check_family, only: [:index, :show, :new, :create, :edit, :update, :destroy]
 
   DIARY_COUNT = 5
 
@@ -11,7 +11,7 @@ class DiariesController < ApplicationController
 
   def show
     @diary = current_user.family.diaries.find(params[:id])
-  rescue ActiveRecord::RecordNotFound
+rescue ActiveRecord::RecordNotFound
     redirect_to diaries_path, alert: '指定された日記が見つからないか、閲覧権限がありません。'
   end
 

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -46,7 +46,7 @@ rescue ActiveRecord::RecordNotFound
     if @diary.update(diary_params)
       redirect_to diary_path(@diary.id), notice: '日記を更新しました。', status: :see_other
     else
-      @children = Child.where(family_id: current_user.family_id)
+      @children = current_user.family.children
       @emojis = Emoji.all
       render :edit, status: :unprocessable_entity
     end
@@ -64,7 +64,7 @@ rescue ActiveRecord::RecordNotFound
   end
 
   def filter
-    # 1. ベースのクエリ（N+1対策含む）
+    # 1. ベースのクエリ
     @diaries = current_user.family.diaries.includes(:children, :emoji).order(date: :desc).page(params[:page]).per(DIARY_COUNT)
 
     # パラメータの整理
@@ -82,7 +82,7 @@ rescue ActiveRecord::RecordNotFound
       @selected_children = current_user.family.children.where(id: @target_child_ids)
     end
 
-    # 3. 絵文字での絞り込み (if を独立させて子供の絞り込み結果に対してさらに絞り込む)
+    # 3. 絵文字での絞り込み
     if @target_emoji_id.present?
       @diaries = @diaries.where(emoji_id: @target_emoji_id)
       @selected_emoji = Emoji.find_by(id: @target_emoji_id)

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -28,7 +28,7 @@ class DiariesController < ApplicationController
     if @diary.save
       redirect_to diaries_path, notice: '日記を投稿しました。', status: :see_other
     else
-      @children = Child.where(family_id: current_user.family_id)
+      @children = current_user.family.children
       @emojis = Emoji.all
       flash.now[:alert] = '日記の投稿に失敗しました。'
       render :new, status: :unprocessable_entity

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -10,19 +10,21 @@ class DiariesController < ApplicationController
   end
 
   def show
-    @diary = Diary.find(params[:id])
+    @diary = current_user.family.diaries.find(params[:id])
+rescue ActiveRecord::RecordNotFound
+    redirect_to diaries_path, alert: '指定された日記が見つからないか、閲覧権限がありません。'
   end
 
   def new
     @diary = Diary.new
-    @children = Child.where(family_id: current_user.family_id)
+    @children = current_user.family.children
     @emojis = Emoji.all
   end
 
   def create
-    @diary = Diary.new(diary_params)
+    @diary = current_user.diaries.build(diary_params.merge(family_id: current_user.family_id))
     process_child_ids
-    @diary.user_id = current_user.id
+
     if @diary.save
       redirect_to diaries_path, notice: '日記を投稿しました。', status: :see_other
     else
@@ -34,7 +36,7 @@ class DiariesController < ApplicationController
   end
 
   def edit
-    @children = Child.where(family_id: current_user.family_id)
+    @children = current_user.family.children
     @emojis = Emoji.all
     @emoji = @diary.emoji
   end
@@ -113,8 +115,8 @@ class DiariesController < ApplicationController
   end
 
   def set_diary
-    # 他人の日記を編集できないよう、current_userから辿る
-    @diary = current_user.diaries.find(params[:id])
+    # current_userから辿り、現在の家族かつ自分が書いた日記のみ編集・削除可能とする
+    @diary = current_user.family.diaries.where(user_id: current_user.id).find(params[:id])
   rescue ActiveRecord::RecordNotFound
     redirect_to diaries_path, alert: '指定された日記が見つからないか、編集権限がありません。'
   end

--- a/app/controllers/families/members_controller.rb
+++ b/app/controllers/families/members_controller.rb
@@ -35,7 +35,7 @@ module Families
       # 管理者ユーザー以外の脱退処理
       if @user.update(family_id: nil)
         redirect_path = @user == current_user ? root_path : family_members_path(@family)
-        redirect_to family_members_path(@family), notice: "#{@user.name} さんが家族から削除（脱退）されました。", status: :see_other
+        redirect_to redirect_path, notice: "#{@user.name} さんが家族から削除（脱退）されました。", status: :see_other
       else
         redirect_to family_members_path(@family), alert: "家族メンバーの削除（脱退）に失敗しました。"
       end

--- a/app/controllers/families/members_controller.rb
+++ b/app/controllers/families/members_controller.rb
@@ -29,12 +29,15 @@ module Families
     end
 
     def destroy
-      # TODO：作成した家族からは脱退できないようにする
+      # 管理者ユーザーの場合
+      return redirect_to family_members_path(@family), alert: "管理者は家族を脱退することができません。" if @family.owner_id == @user.id
+
+      # 管理者ユーザー以外の脱退処理
       if @user.update(family_id: nil)
         redirect_path = @user == current_user ? root_path : family_members_path(@family)
-        redirect_to redirect_path, notice: "#{@user.name} さんを家族から削除（脱退）しました。", status: :see_other
+        redirect_to family_members_path(@family), notice: "#{@user.name} さんが家族から削除（脱退）されました。", status: :see_other
       else
-        redirect_to family_members_path(@family), alert: "メンバーの削除（脱退）に失敗しました。"
+        redirect_to family_members_path(@family), alert: "家族メンバーの削除（脱退）に失敗しました。"
       end
     end
 

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -1,5 +1,6 @@
 class Diary < ApplicationRecord
   belongs_to :user, optional: true
+  belongs_to :family
   belongs_to :emoji
 
   has_many :diary_children, dependent: :destroy

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -1,5 +1,5 @@
 class Diary < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, optional: true
   belongs_to :emoji
 
   has_many :diary_children, dependent: :destroy

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -2,7 +2,7 @@ class Family < ApplicationRecord
   belongs_to :owner, class_name: 'User', foreign_key: 'owner_id'
   has_many :users
   has_many :children, dependent: :destroy
-  has_many :diaries, through: :users
+  has_many :diaries, dependent: :destroy
 
   validates :name, length: { in: 1..50 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   belongs_to :family, optional: true
   has_one :owned_family, class_name: 'Family', foreign_key: 'owner_id'
   has_one_attached :avatar
-  has_many :diaries, dependent: :destroy
+  has_many :diaries, dependent: :nullify
   has_many :reactions
 
   attr_accessor :password, :password_confirmation

--- a/app/views/families/members/index.html.erb
+++ b/app/views/families/members/index.html.erb
@@ -34,7 +34,7 @@
           <% end %>
         </div>
         
-        <% if @family.owner_id == current_user.id || member.id == current_user.id %>
+        <% if member.id == current_user.id && @family.owner_id != current_user.id || @family.owner_id == current_user.id && member.id != current_user.id %>
           <div class="pt-3 border-t border-amber-50">
             <%= button_to family_member_path(@family, member), method: :delete, data: { turbo_confirm: "本当にこのメンバーを家族から削除しますか？" }, class: "w-full py-2.5 bg-white border-2 border-rose-400 text-rose-500 hover:bg-rose-50 font-bold rounded-full text-sm transition-all active:scale-95 flex items-center justify-center cursor-pointer" do %> <span class="icon-[mdi--account-remove-outline] mr-2 text-lg"></span>
               <%= delete_or_optout(member) %>

--- a/db/migrate/20260126020001_add_family_to_diaries.rb
+++ b/db/migrate/20260126020001_add_family_to_diaries.rb
@@ -1,19 +1,5 @@
 class AddFamilyToDiaries < ActiveRecord::Migration[7.1]
   def change
-    # null: true（NULLを許可）でカラムを追加
-    add_reference :diaries, :family, foreign_key: true
-  
-    # 既存の日記データに、投稿したユーザーの family_id を流し込む（データマイグレーション）
-    up_only do
-      Diary.find_each do |diary|
-        # ユーザーが家族に所属している場合のみ、その family_id をセット
-        if diary.user.family_id
-          diary.update_column(:family_id, diary.user.family_id)
-        end
-      end
-    end
-
-    # 最後に NULL を禁止する制約をつける
-    change_column_null :diaries, :family_id, false
+    add_reference :diaries, :family, null: false, foreign_key: true
   end
 end

--- a/db/migrate/20260126020001_add_family_to_diaries.rb
+++ b/db/migrate/20260126020001_add_family_to_diaries.rb
@@ -1,0 +1,19 @@
+class AddFamilyToDiaries < ActiveRecord::Migration[7.1]
+  def change
+    # null: true（NULLを許可）でカラムを追加
+    add_reference :diaries, :family, foreign_key: true
+  
+    # 既存の日記データに、投稿したユーザーの family_id を流し込む（データマイグレーション）
+    up_only do
+      Diary.find_each do |diary|
+        # ユーザーが家族に所属している場合のみ、その family_id をセット
+        if diary.user.family_id
+          diary.update_column(:family_id, diary.user.family_id)
+        end
+      end
+    end
+
+    # 最後に NULL を禁止する制約をつける
+    change_column_null :diaries, :family_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_26_020803) do
+ActiveRecord::Schema[7.1].define(version: 2026_01_26_020001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -58,7 +58,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_26_020803) do
     t.bigint "emoji_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "family_id", null: false
     t.index ["emoji_id"], name: "index_diaries_on_emoji_id"
+    t.index ["family_id"], name: "index_diaries_on_family_id"
     t.index ["user_id"], name: "index_diaries_on_user_id"
   end
 
@@ -115,6 +117,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_26_020803) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "children", "families"
   add_foreign_key "diaries", "emojis"
+  add_foreign_key "diaries", "families"
   add_foreign_key "diaries", "users"
   add_foreign_key "diary_children", "children"
   add_foreign_key "diary_children", "diaries"


### PR DESCRIPTION
## 概要
家族メンバーを削除（脱退）する処理の修正

## 関連issue
#202 

## やったこと
 - 家族の作成者（管理者ユーザー）は、家族から脱退できない仕様に変更
 - ユーザーが家族から脱退しても、投稿した日記は元の家族のメンバーが閲覧できるように変更
	 - `diaries`テーブルに`family_id`カラムを追加
	 - `Diary`モデルに`Family`モデルを関連付け
	 - `Family`が`User`を介さずに`Diary`を`has_many`する記述に変更
	 - `diaries_controller`において`Diary`や`Child`の情報を取得する際のロジックを修正

## やらないこと
 - 

## テスト／完了確認
 - [x] 管理者ユーザーが家族から脱退できないようになっていることを確認
 - [x] ユーザーが家族から脱退しても、投稿した日記は元の家族が見れることを確認