### PR TITLE
Fix/#206 日記一覧表示においてデフォルトのプロフィール画像が表示されるよう修正

### DIFF
--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -24,11 +24,7 @@
     <div class="flex-shrink-0">
       <div class="relative">
         <div class="size-10 rounded-full bg-gray-200 overflow-hidden ring-2 ring-primary/20">
-          <% if diary.user.avatar.attached? %>
-            <%= image_tag diary.user.avatar, class: "w-full h-full object-cover" %>
-          <% else %>
-            <img alt="<%= diary.user.name %> portrait" class="w-full h-full object-cover" src="https://via.placeholder.com/48/F5A30A/FFFFFF?text=<%= diary.user.name.first %>" />
-          <% end %>
+          <%= image_tag diary.user.display_avatar, class: "w-full h-full object-cover" %>
         </div>
       </div>
     </div>

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -62,7 +62,7 @@
     </div>
 
     <!-- Bottom section: User info moved to footer -->
-    <div class="min-w-full bg-lime-200/90 px-6 py-4 border-t-1 border-lime-500 flex items-center">
+    <div class="min-w-full bg-lime-200/90 px-4 py-4 border-t-1 border-lime-500 flex items-center">
       <div class="min-w-full flex items-center gap-3">
         <div class="size-12 rounded-full bg-gray-200 overflow-hidden ring-2 ring-lime-600">
           <%= image_tag @diary.user.display_avatar, class: "w-full h-full object-cover" %>
@@ -73,7 +73,7 @@
         </div>
         <% if @diary.user == current_user %>
         <div class="flex-auto text-right">
-          <%= button_to t('helpers.submit.diary.edit'), edit_diary_path(diary_id: @diary.id), method: :get, data: { turbo: false }, class: "bg-amber-400 hover:bg-amber-500 text-amber-800 font-bold py-2 px-6 rounded-full shadow-md transition duration-300 ease-in-out" %>
+          <%= button_to t('helpers.submit.diary.edit'), edit_diary_path(diary_id: @diary.id), method: :get, data: { turbo: false }, class: "bg-amber-400 hover:bg-amber-500 text-amber-800 font-bold text-sm py-2 px-3 rounded-full shadow-sm transition duration-300 ease-in-out" %>
         </div>
         <% end %>
       </div>

--- a/app/views/layouts/_menu.html.erb
+++ b/app/views/layouts/_menu.html.erb
@@ -2,28 +2,28 @@
   <div id="new_article" class="flex flex-col items-center justify-center">
     <%= link_to new_diary_path, data: { turbo: false }, class: "flex flex-col items-center gap-1 group" do %>
       <span class="icon-[lucide--plus-circle] text-2xl text-amber-500 transition-transform group-active:scale-95"></span>
-      <span class="text-[10px] font-bold text-amber-800">日記投稿</span>
+      <span class="text-[12px] font-bold text-amber-800">日記投稿</span>
     <% end %>
   </div>
 
   <div id="go_to_home" class="flex flex-col items-center justify-center">
     <%= link_to diaries_path, data: { turbo: false }, class: "flex flex-col items-center gap-1 group" do %>
       <span class="icon-[lucide--calendar] text-2xl text-amber-500 transition-transform group-active:scale-95"></span>
-      <span class="text-[10px] font-bold text-amber-800">ホーム</span>
+      <span class="text-[12px] font-bold text-amber-800">ホーム</span>
     <% end %>
   </div>
 
   <div id="search" class="flex flex-col items-center justify-center">
     <%= link_to diaries_path, data: { turbo: false }, class: "flex flex-col items-center gap-1 group" do %>
       <span class="icon-[lucide--search] text-2xl text-amber-500 transition-transform group-active:scale-95"></span>
-      <span class="text-[10px] font-bold text-amber-800">検索</span>
+      <span class="text-[12px] font-bold text-amber-800">検索</span>
     <% end %>
   </div>
 
   <div id="my_page" class="flex flex-col items-center justify-center">
     <%= link_to mypage_path, data: { turbo: false }, class: "flex flex-col items-center gap-1 group" do %>
       <span class="icon-[lucide--user] text-2xl text-amber-500 transition-transform group-active:scale-95"></span>
-      <span class="text-[10px] font-bold text-amber-800">マイページ</span>
+      <span class="text-[12px] font-bold text-amber-800">マイページ</span>
     <% end %>
   </div>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -98,7 +98,7 @@ ja:
         submit: 保存する
         update: 更新する
         destroy: 削除する
-        edit: 編集する
+        edit: 編集
       user:
         create: 登録する
         submit: ログイン


### PR DESCRIPTION
## 概要
日記の一覧表示においてデフォルトのプロフィール画像が表示されるよう修正した

## 関連issue
#206 

## やったこと
 - `diary`パーシャルのコードを`display_avatar`メソッドを利用したものに修正
 - `diaries/show`のレイアウトを調整
 - メニュー部の文字サイズを`12`に変更

## やらないこと
 - 

## テスト／完了確認
 - [x] 日記の一覧表示においてデフォルトのプロフィール画像が表示されることを確認