### PR TITLE
Fix/ #208 日記に複数の子どもを紐づけられない不具合を修正

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -108,7 +108,7 @@ rescue ActiveRecord::RecordNotFound
 
   def process_child_ids
     # 文字列を数値の配列に変換してセットする
-    return unless params[:diary][:child_ids].is_a?(String)
+    return unless params[:diary][:child_ids].present? && params[:diary][:child_ids].is_a?(String)
 
     params[:diary][:child_ids] = params[:diary][:child_ids].split(',')
     @diary.child_ids = params[:diary][:child_ids]

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -2,6 +2,7 @@ class DiariesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_diary, only: [:edit, :update, :destroy]
   before_action :check_family, only: [:index, :show, :new, :create, :edit, :update, :destroy]
+  before_action :process_child_ids, only: [:create, :update]
 
   DIARY_COUNT = 5
 
@@ -23,7 +24,6 @@ rescue ActiveRecord::RecordNotFound
 
   def create
     @diary = current_user.diaries.build(diary_params.merge(family_id: current_user.family_id))
-    process_child_ids
 
     if @diary.save
       redirect_to diaries_path, notice: '日記を投稿しました。', status: :see_other
@@ -42,7 +42,6 @@ rescue ActiveRecord::RecordNotFound
   end
 
   def update
-    process_child_ids
     if @diary.update(diary_params)
       redirect_to diary_path(@diary.id), notice: '日記を更新しました。', status: :see_other
     else
@@ -107,11 +106,9 @@ rescue ActiveRecord::RecordNotFound
   end
 
   def process_child_ids
-    # 文字列を数値の配列に変換してセットする
     return unless params[:diary][:child_ids].present? && params[:diary][:child_ids].is_a?(String)
-
+    # 文字列を数値の配列に変換してセットする
     params[:diary][:child_ids] = params[:diary][:child_ids].split(',')
-    @diary.child_ids = params[:diary][:child_ids]
   end
 
   def set_diary

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -2,9 +2,8 @@ class ReactionsController < ApplicationController
   def create
     @diary = Diary.find(params[:diary_id])
 
-    # 1. 家族チェック（日記の家族IDと、自分の家族IDが一致するか）
-    # 2. 自分自身ではないチェック（日記の投稿者と自分が一致しないか）
-    if @diary.user.family_id == current_user.family_id && @diary.user_id != current_user.id
+    # 日記の家族IDと自分の家族IDが一致する、かつ日記の投稿者と自分が一致しないかどうか
+    if @diary.family_id == current_user.family_id && @diary.user_id != current_user.id
       @reaction = @diary.reactions.new(
         user: current_user,
         emoji_id: params[:emoji_id]

--- a/app/views/diaries/_reaction_palette.html.erb
+++ b/app/views/diaries/_reaction_palette.html.erb
@@ -1,5 +1,5 @@
 <% my_reactions_count = diary.reactions.where(user_id: current_user.id).count %>
-<% if diary.user_id != current_user.id && diary.user.family_id == current_user.family_id && my_reactions_count < 5 %>
+<% if diary.user_id != current_user.id && diary.family_id == current_user.family_id && my_reactions_count < 5 %>
   <style>
     #diary_<%= diary.id %>:has(details[open]) {
       z-index: 50 !important;

--- a/app/views/diaries/edit.html.erb
+++ b/app/views/diaries/edit.html.erb
@@ -35,7 +35,7 @@
             <%= f.label :child_ids, "どの子？", class: "font-semibold text-amber-800 text-lg" %>
           </div>
           <div class="relative">
-            <%= f.select :child_ids, Diary.child_combination_options(current_user.family), { include_blank: "選択してください", selected: f.object.child_ids }, { name: "diary[child_ids][]", class: "w-full p-3 border border-amber-400 rounded-lg bg-white text-lime-800 text-md shadow-sm appearance-none cursor-pointer" } %>
+            <%= f.select :child_ids, Diary.child_combination_options(current_user.family), { include_blank: "選択してください", selected: f.object.child_ids }, { name: "diary[child_ids]", class: "w-full p-3 border border-amber-400 rounded-lg bg-white text-lime-800 text-md shadow-sm appearance-none cursor-pointer" } %>
           </div>
         </div>
 

--- a/app/views/diaries/edit.html.erb
+++ b/app/views/diaries/edit.html.erb
@@ -35,7 +35,12 @@
             <%= f.label :child_ids, "どの子？", class: "font-semibold text-amber-800 text-lg" %>
           </div>
           <div class="relative">
-            <%= f.select :child_ids, Diary.child_combination_options(current_user.family), { include_blank: "選択してください", selected: f.object.child_ids }, { name: "diary[child_ids]", class: "w-full p-3 border border-amber-400 rounded-lg bg-white text-lime-800 text-md shadow-sm appearance-none cursor-pointer" } %>
+            <%= f.select :child_ids, Diary.child_combination_options(current_user.family), 
+            {
+              include_blank: "選択してください",
+              # 現在紐付いている子どものIDを、昇順でソートしてカンマ区切りの文字列に変換
+              selected: @diary.child_ids.sort.join(',')
+            }, { name: "diary[child_ids]", class: "w-full p-3 border border-amber-400 rounded-lg bg-white text-lime-800 text-md shadow-sm appearance-none cursor-pointer" } %>
           </div>
         </div>
 

--- a/app/views/diaries/new.html.erb
+++ b/app/views/diaries/new.html.erb
@@ -35,7 +35,7 @@
             <%= f.label :child_ids, "どの子？", class: "font-semibold text-amber-800 text-lg" %>
           </div>
           <div class="relative">
-            <%= f.select :child_ids, Diary.child_combination_options(current_user.family), { include_blank: "選択してください", selected: f.object.child_ids }, { name: "diary[child_ids][]", class: "w-full p-3 border border-amber-400 rounded-lg bg-white text-lime-800 text-md shadow-sm appearance-none cursor-pointer" } %>
+            <%= f.select :child_ids, Diary.child_combination_options(current_user.family), { include_blank: "選択してください", selected: f.object.child_ids }, { name: "diary[child_ids]", class: "w-full p-3 border border-amber-400 rounded-lg bg-white text-lime-800 text-md shadow-sm appearance-none cursor-pointer" } %>
           </div>
         </div>
 


### PR DESCRIPTION
## 概要
日記に複数の子どもの情報を紐づけられない不具合を修正

## 関連issue
#208 

## やったこと
 - ビューファイルから複数の子どもの情報の値がきちんと渡るように修正
	 - `diaries/new`
	 - `diaries/edit`
 - この修正に伴い、`diaries_controller.rb`の記述も調整
 - 脱退した家族メンバーの日記にリアクションが追加できるようにビューファイルとコントローラーを修正

## やらないこと
 - 

## テスト／完了確認
 - [x] 日記の新規投稿時、複数の子どもの情報を紐づけられることを確認
 - [x] 日記更新時、複数の子どもの情報を紐づけて更新できることを確認
 - [x] 日記編集時、登録した複数の子どもの情報に基づいてプルダウンメニューが選択されていることを確認
 - [x] 家族から脱退したメンバーが投稿した日記にも、リアクションが付与できることを確認