### PR TITLE
Test: Userのモデルスペックを追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,5 +8,6 @@ AllCops:
     - 'node_modules/**/*'
     - 'db/**/*'
     - 'test/**/**'
+    - 'spec/**/*'
   Rails:
     enabled: true

--- a/spec/factories/families.rb
+++ b/spec/factories/families.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :family do
+    name { 'ファミリー' }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:email) { "test#{_1}@example.com" }
+    password { 'password123' }
+    password_confirmation { password }
+    name { '名前太郎' }
+    birthday { '1999-01-01' }
+    sequence(:supabase_uid) { "supabase_uid_test#{_1}" }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,5 +6,53 @@ FactoryBot.define do
     name { '名前太郎' }
     birthday { '1999-01-01' }
     sequence(:supabase_uid) { "supabase_uid_test#{_1}" }
+
+    trait :no_name do
+      name { '' }
+    end
+
+    trait :nil_name do
+      name { nil }
+    end
+
+    trait :one_character_name do
+      name { 'a' }
+    end
+
+    trait :blank_character_name do
+      name { ' ' }
+    end
+
+    trait :contain_blank_name do
+      name { '名前 太郎' }
+    end
+
+    trait :contain_full_width_blank_name do
+      name { '空白　次郎' }
+    end
+
+    trait :only_half_width_character_name do
+      name { 'abcdef' }
+    end
+
+    trait :only_half_width_symbol_name do
+      name { "!@#$%^&*()_+" }
+    end
+
+    trait :only_full_width_symbol_name do
+      name { "！＠＃＄％＆（）＝＊＋ー「」？＞＜" }
+    end
+
+    trait :mixed_half_width_and_full_width_character_name do
+      name { '名前nameさぶろう1' }
+    end
+
+    trait :contain_half_width_symbol_name do
+      name { '名前と記号!@#$%^&*()_+' }
+    end
+
+    trait :too_long_name do
+      name { 'あ' * 51 }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -150,5 +150,18 @@ FactoryBot.define do
     trait :nil_password_confirmation do
       password_confirmation { nil }
     end
+
+    trait :future_birthday do
+      date = Date.today
+      birthday { date+1 }
+    end
+
+    trait :no_supabase_uid do
+      supabase_uid { "" }
+    end
+
+    trait :nil_supabase_uid do
+      supabase_uid { nil }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -115,10 +115,6 @@ FactoryBot.define do
       password { nil }
     end
 
-    trait :nil_password do
-      password { nil }
-    end
-
     trait :contain_blank_password do
       password { "pas sword" }
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -54,5 +54,53 @@ FactoryBot.define do
     trait :too_long_name do
       name { 'あ' * 51 }
     end
+
+    trait :no_email do
+      email { '' }
+    end
+
+    trait :nil_email do
+      email { nil }
+    end
+
+    trait :one_character_email do
+      email { 'a' }
+    end
+
+    trait :thousand_character_email do
+      email { 'a' * 500 + '@' + 'b' * 499 }
+    end
+
+    trait :contain_blank_email do
+      email { "test @example.com" }
+    end
+
+    trait :only_full_width_character_email do
+      email { 'メールアドレス' }
+    end
+
+    trait :contain_full_width_character_email do
+      email { "てすと@example.com" }
+    end
+
+    trait :except_atmark_from_email do
+      email { "testexample.com" }
+    end
+
+    trait :only_half_width_symbol_email do
+      email { "!@#$%^&*()_+" }
+    end
+
+    trait :contain_half_width_symbol_email do
+      email { "!#$%test@example^&*()+.com" }
+    end
+
+    trait :except_username_from_email do
+      email { "@example.com" }
+    end
+
+    trait :except_domain_from_email do
+      email { "test@" }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -142,5 +142,13 @@ FactoryBot.define do
     trait :contain_half_width_symbol_password do
       password { "pass123!?" }
     end
+
+    trait :no_password_confirmation do
+      password_confirmation { "" }
+    end
+
+    trait :nil_password_confirmation do
+      password_confirmation { nil }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -102,5 +102,45 @@ FactoryBot.define do
     trait :except_domain_from_email do
       email { "test@" }
     end
+
+    trait :too_short_password do
+      password { "passw" }
+    end
+
+    trait :blank_character_password do
+      password { "" }
+    end
+
+    trait :nil_password do
+      password { nil }
+    end
+
+    trait :nil_password do
+      password { nil }
+    end
+
+    trait :contain_blank_password do
+      password { "pas sword" }
+    end
+
+    trait :only_full_width_character_password do
+      password { "パスワードテスト" }
+    end
+
+    trait :contain_full_width_character_password do
+      password { "パスword" }
+    end
+
+    trait :only_half_width_symbol_password do
+      password { "!@#$%^&*()_+" }
+    end
+
+    trait :six_character_password do
+      password { "pass12" }
+    end
+
+    trait :contain_half_width_symbol_password do
+      password { "pass123!?" }
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -194,6 +194,16 @@ RSpec.describe User, type: :model do
       end
 
       context 'E2. password_confirmationのバリデーションが無効：' do
+        it 'password_confirmationが未入力のため無効' do
+          user = build(:user, password_confirmation: "" )
+          user.valid?
+          expect(user.errors.full_messages).to include("パスワード（確認）がパスワードと一致しません")
+        end
+        it 'password_confirmationがnilのため無効' do
+          user = build(:user, password_confirmation: nil )
+          user.valid?
+          expect(user.errors.full_messages).to include("パスワード（確認）がパスワードと一致しません")
+        end
         it 'password_confirmationがpasswordと不一致のため無効' do
           user = build(:user, password_confirmation: "passwords" )
           user.valid?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -52,11 +52,90 @@ RSpec.describe User, type: :model do
           user.valid?
           expect(user.errors.full_messages).to include("表示名を入力してください")
         end
-        it '4. nameが51文字以上であるため無効' do
-          user = build(:user, :too_long_name)
+        # it '4. nameが51文字以上であるため無効' do
+        #   nameに文字数制限のバリデーションを付けること
+        #   user = build(:user, :too_long_name)
+        #   user.valid?
+        #   expect(user.errors.full_messages).to include("50文字以内で入力してください")
+        # end
+      end
+
+      context 'C. emailのバリデーションが無効：' do
+        it 'emailが空であるため無効' do
+          user = build(:user, :no_email)
           user.valid?
-          expect(user.errors.full_messages).to include("50文字以内で入力してください")
+          expect(user.errors.full_messages).to include("メールアドレスを入力してください")
         end
+        it 'emailがnilであるため無効' do
+          user = build(:user, :nil_email)
+          user.valid?
+          expect(user.errors.full_messages).to include("メールアドレスを入力してください")
+        end
+        it '既に存在するemailのデータと被っているため無効' do
+          first_user = create(:user)
+          user = build(:user, email: first_user.email)
+          user.valid?
+          expect(user.errors.full_messages).to include("メールアドレスはすでに存在します")
+        end
+=begin
+        it 'emailが1文字しか入力されていないため無効' do
+          user = build(:user, :one_character_email)
+          user.valid?
+          expect(user.errors.full_messages).to include("")
+        end
+        it 'emailが1000文字以上入力されたため無効' do
+          user = build(:user, :thousand_character_email)
+          user.valid?
+          expect(user.errors.full_messages).to include("")
+        end
+        it 'emailに空白文字が含まれているため無効' do
+          user = build(:user, :contain_blank_email)
+          user.valid?
+          expect(user.errors.full_messages).to include("")
+        end
+        it 'emailが全角文字のみで入力されたため無効' do
+          user = build(:user, :only_full_width_character_email)
+          user.valid?
+          expect(user.errors.full_messages).to include("")
+        end
+        it 'emailが全角文字を含んでいるため無効' do
+          user = build(:user, :contain_full_width_character_email)
+          user.valid?
+          expect(user.errors.full_messages).to include("")
+        end
+        it 'emailに@が入っていないため無効' do
+          user = build(:user, :except_atmark_from_email)
+          user.valid?
+          expect(user.errors.full_messages).to include("")
+        end
+        it 'emailが半角記号のみ入力されたため無効' do
+          user = build(:user, :only_half_width_symbol_email)
+          user.valid?
+          expect(user.errors.full_messages).to include("")
+        end
+        it 'emailが@、_、.以外の半角記号を含んでいるため無効' do
+          user = build(:user, :contain_half_width_symbol_email)
+          user.valid?
+          expect(user.errors.full_messages).to include("")
+        end
+        it 'emailのユーザー名の部分を大文字で登録すると、小文字として一意性が保たれるため無効' do
+          # emailに case_sensitive: false を設定し、エラーメッセージを確認すること
+          create(:user, email: 'test@example.com')
+          user = build(:user, email: 'TEST@EXAMPLE.COM')
+          user.valid
+          expect(user.errors.full_messages).to include("")
+        end
+        it '@前のユーザー名が記入されていないため無効' do
+          user = build(:user, :except_username_from_email)
+          user.valid?
+          expect(user.errors.full_messages).to include("")
+        end
+        it '@後のドメイン名が記入されていないため無効' do
+          user = build(:user, :except_domain_from_email)
+          user.valid?
+          expect(user.errors.full_messages).to include("")
+        end
+=end
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -195,12 +195,12 @@ RSpec.describe User, type: :model do
 
       context 'E2. password_confirmationのバリデーションが無効：' do
         it 'password_confirmationが未入力のため無効' do
-          user = build(:user, password_confirmation: "" )
+          user = build(:user, :no_password_confirmation)
           user.valid?
           expect(user.errors.full_messages).to include("パスワード（確認）がパスワードと一致しません")
         end
         it 'password_confirmationがnilのため無効' do
-          user = build(:user, password_confirmation: nil )
+          user = build(:user, :nil_password_confirmation)
           user.valid?
           expect(user.errors.full_messages).to include("パスワード（確認）がパスワードと一致しません")
         end
@@ -209,6 +209,37 @@ RSpec.describe User, type: :model do
           user.valid?
           expect(user.errors.full_messages).to include("パスワード（確認）がパスワードと一致しません")
         end
+      end
+
+      context 'F. birthdayのバリデーションが無効：' do
+=begin
+        it 'birthdayが未来の日付のため無効' do
+          user = build(:user, :future_birthday)
+          p user.valid?
+          expect(user.errors.full_messages).to include("")
+        end
+=end
+      end
+
+      context 'G1. supabase_uidのバリデーションが有効：' do
+        it 'supabase_uidが空白のため有効' do
+          expect(build(:user, :no_supabase_uid)).to be_valid
+        end
+        it 'supabase_uidがnilのため有効' do
+          expect(build(:user, :nil_supabase_uid)).to be_valid
+        end
+      end
+
+      context 'G2. supabase_uidのバリデーションが無効：' do
+=begin
+        it '既に存在するsupabase_uidのデータと被っているため無効' do
+          # uniqueness : true を付与すべきなのかどうかAIに相談
+          first_user = create(:user)
+          user = build(:user, supabase_uid: first_user.supabase_uid)
+          user.valid?
+          expect(user.errors.full_messages).to include("")
+        end
+=end
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -204,12 +204,12 @@ RSpec.describe User, type: :model do
         it 'password_confirmationが未入力のため無効' do
           user = build(:user, :no_password_confirmation)
           user.valid?
-          expect(user.errors.full_messages).to include("パスワード（確認）がパスワードと一致しません")
+          expect(user.errors.details[:password_confirmation]).to include({:error => :blank})
         end
         it 'password_confirmationがnilのため無効' do
           user = build(:user, :nil_password_confirmation)
           user.valid?
-          expect(user.errors.full_messages).to include("パスワード（確認）がパスワードと一致しません")
+          expect(user.errors.details[:password_confirmation]).to include({:error => :blank})
         end
         it 'password_confirmationがpasswordと不一致のため無効' do
           user = build(:user, password_confirmation: "passwords" )
@@ -270,8 +270,8 @@ RSpec.describe User, type: :model do
           expect(user.owned_family).to eq family
         end
         it 'いずれの家族グループの管理者ユーザーでない場合、owned_familyでnilが返ってくる' do
-          user = build(:user, owned_family: nil)
-          expect(user.owned_family).to eq nil
+          user = create(:user)
+          expect(user.owned_family).to be_nil
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -60,7 +60,14 @@ RSpec.describe User, type: :model do
         # end
       end
 
-      context 'C. emailのバリデーションが無効：' do
+      # context 'C1. emailのバリデーションが有効：' do
+      #   it 'emailが大文字で入力・保存されても、DB上では小文字で保存されている' do
+      #     user = create(:user, email: 'TEST@EXAMPLE.COM')
+      #     expect(user.reload.email).to eq 'test@example.com'
+      #   end
+      # end
+
+      context 'C2. emailのバリデーションが無効：' do
         it 'emailが空であるため無効' do
           user = build(:user, :no_email)
           user.valid?
@@ -240,6 +247,32 @@ RSpec.describe User, type: :model do
           expect(user.errors.full_messages).to include("")
         end
 =end
+      end
+    end
+
+    describe 'アソシエーション：' do
+      context 'A. 家族グループへの所属' do
+        let(:user) { create(:user) }
+        let(:family) { create(:family, owner_id: user.id) }
+        it 'Userのfamily_idに、存在するFamilyのIDを設定し、紐づけられたFamilyのオブジェクトが返ってくる' do
+          user.family_id = family.id
+          expect(user.family).to eq family
+        end
+        it 'Userのfamily_idがnilであっても有効となる' do
+          expect(build(:user, family_id: nil)).to be_valid
+        end
+      end
+
+      context 'B. 管理者ユーザーとしての家族グループの紐づけ' do
+        let!(:user) { create(:user) }
+        let!(:family) { create(:family, owner_id: user.id) }
+        it 'owned_familyでUserが管理者ユーザーとなっているFamilyのオブジェクトが返ってくる' do
+          expect(user.owned_family).to eq family
+        end
+        it 'いずれの家族グループの管理者ユーザーでない場合、owned_familyでnilが返ってくる' do
+          user = build(:user, owned_family: nil)
+          expect(user.owned_family).to eq nil
+        end
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -137,6 +137,69 @@ RSpec.describe User, type: :model do
         end
 =end
       end
+
+      context 'D1. passwordのバリデーションが有効：' do
+        it 'passwordが6文字であるため有効' do
+          expect(build(:user, :six_character_password)).to be_valid
+        end
+        it 'passwordに半角記号が含まれているため有効' do
+          expect(build(:user, :contain_half_width_symbol_password)).to be_valid
+        end
+      end
+
+      context 'D2. passwordのバリデーションが無効：' do
+        it 'passwordが6文字未満であるため無効' do
+          user = build(:user, :too_short_password)
+          user.valid?
+          expect(user.errors.full_messages).to include("パスワードは6文字以上で入力してください")
+        end
+        it 'passwordが空白であるため無効' do
+          user = build(:user, :blank_character_password)
+          user.valid?
+          expect(user.errors.full_messages).to include("パスワードを入力してください")
+        end
+        it 'passwordがnilであるため無効' do
+          user = build(:user, :nil_password)
+          user.valid?
+          expect(user.errors.full_messages).to include("パスワードを入力してください")
+        end
+=begin
+        it 'passwordが空白文字を含むため無効' do
+          user = build(:user, :contain_blank_password)
+          p user.valid?
+          expect(user.errors.full_messages).to include("")
+        end
+        it 'passwordが全角文字のみ入力されているため無効' do
+          user = build(:user, :only_full_width_character_password)
+          p user.valid?
+          expect(user.errors.full_messages).to include("")
+        end
+        it 'passwordに全角文字が含まれているため無効' do
+          user = build(:user, :contain_full_width_character_password)
+          p user.valid?
+          expect(user.errors.full_messages).to include("")
+        end
+        it 'passwordが半角記号のみ入力されているため無効' do
+          user = build(:user, :only_half_width_symbol_password)
+          p user.valid?
+          expect(user.errors.full_messages).to include("")
+        end
+=end
+      end
+
+      context 'E1. password_confirmationのバリデーションが有効：' do
+        it 'password_confirmationがpasswordと一致しているため有効' do
+          expect(build(:user, password: 'pass123word', password_confirmation: 'pass123word')).to be_valid
+        end
+      end
+
+      context 'E2. password_confirmationのバリデーションが無効：' do
+        it 'password_confirmationがpasswordと不一致のため無効' do
+          user = build(:user, password_confirmation: "passwords" )
+          user.valid?
+          expect(user.errors.full_messages).to include("パスワード（確認）がパスワードと一致しません")
+        end
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,63 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  
+  describe '新規登録：' do
+    describe 'バリデーション：' do
+      context 'A. バリデーション通過：' do
+        it '全ての項目が適切に入力されており有効' do
+          expect(build(:user)).to be_valid
+        end
+      end
+
+      context 'B1. nameのバリデーションが有効：' do
+        it '1. nameが1文字のみ入力されており有効' do
+          expect(build(:user, :one_character_name)).to be_valid
+        end
+        it '2. nameが半角スペースを含んでおり有効' do
+          expect(build(:user, :contain_blank_name)).to be_valid
+        end
+        it '3. nameが全角スペースを含んでおり有効' do
+          expect(build(:user, :contain_full_width_blank_name)).to be_valid
+        end
+        it '4. nameが半角文字のみであり有効' do
+          expect(build(:user, :only_half_width_character_name)).to be_valid
+        end
+        it '5. nameが半角記号のみであり有効' do
+          expect(build(:user, :only_half_width_symbol_name)).to be_valid
+        end
+        it '6. nameが全角記号のみであり有効' do
+          expect(build(:user, :only_full_width_symbol_name)).to be_valid
+        end
+        it '7. nameが全角文字と半角文字を含んでおり有効' do
+          expect(build(:user, :mixed_half_width_and_full_width_character_name)).to be_valid
+        end
+        it '8. nameが全角文字と半角記号を含んでおり有効' do
+          expect(build(:user, :contain_half_width_symbol_name)).to be_valid
+        end
+      end
+
+      context 'B2. nameのバリデーションが無効：' do
+        it '1. nameが空であるため無効' do
+          user = build(:user, :no_name)
+          user.valid?
+          expect(user.errors.full_messages).to include("表示名を入力してください")
+        end
+        it '2. nameがnilであるため無効' do
+          user = build(:user, :nil_name)
+          user.valid?
+          expect(user.errors.full_messages).to include("表示名を入力してください")
+        end
+        it '3. nameが空白文字のみであるため無効' do
+          user = build(:user, :blank_character_name)
+          user.valid?
+          expect(user.errors.full_messages).to include("表示名を入力してください")
+        end
+        it '4. nameが51文字以上であるため無効' do
+          user = build(:user, :too_long_name)
+          user.valid?
+          expect(user.errors.full_messages).to include("50文字以内で入力してください")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
`User`のモデルスペックを追加、テストコードを記述

## 関連issue
#216 

## やったこと
 - FactoryBotに`:user`を定義
 - 各テストケースに必要なtraitを定義
 - `user_spec.rb`にテストを記述
 - LintチェックからRSpecのファイルを除外

## やらないこと
 - `Family`モデルのテストを書く
 - 実装していない部分のテストを実行する
	 - 未実装の部分に関してのテストケースはコメントアウトしてある

## テスト／完了確認
 - [x] GeminiとAI講師にテストケースの網羅性やモデルスペックの書き方が問題ないという評価をもらう
 - [x] 実装済みの部分に関して、テストが問題なく通ることを確認