### PR TITLE
Feature/#218 Userモデルにバリデーションを追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ uniqueness: { case_sensitive: false },
   validates :password, presence: true, length: { minimum: 6 }, on: :create
   validates :password_confirmation, presence: true, on: :create
   validate :password_match, on: :create
-  validates :name, presence: true
+  validates :supabase_uid, uniqueness: true, allow_nil: true
 
   def can_create_family?
     family_id.nil? && owned_family.nil?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,14 +7,15 @@ class User < ApplicationRecord
 
   attr_accessor :password, :password_confirmation
 
-before_save { self.email = self.email.downcase }
+  before_save { self.email = self.email.downcase }
 
   validates :email, presence: true,
-uniqueness: { case_sensitive: false },
+                    uniqueness: { case_sensitive: false },
                     format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :password, presence: true, length: { minimum: 6 }, on: :create
   validates :password_confirmation, presence: true, on: :create
   validate :password_match, on: :create
+  validates :name, presence: true, length: { maximum: 50 }
   validates :supabase_uid, uniqueness: true, allow_nil: true
 
   def can_create_family?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
 
   attr_accessor :password, :password_confirmation
 
-  before_save { self.email = self.email.downcase }
+  before_save { self.email = email.downcase }
 
   validates :email, presence: true,
                     uniqueness: { case_sensitive: false },
@@ -15,7 +15,7 @@ class User < ApplicationRecord
   validates :password, presence: true,
                        format: { with: /\A(?=.*[a-zA-Z0-9])[!-~]+\z/,
                                  message: 'は英数字のいずれかを必ず含む、英数字と半角記号のみにしてください' },
-length: { minimum: 6 }, on: :create
+                       length: { minimum: 6 }, on: :create
   validates :password_confirmation, presence: true, on: :create
   validate :password_match, on: :create
   validates :name, presence: true, length: { maximum: 50 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,7 @@ class User < ApplicationRecord
   validates :password_confirmation, presence: true, on: :create
   validate :password_match, on: :create
   validates :name, presence: true, length: { maximum: 50 }
+  validate :birthday_cannot_be_in_the_future
   validates :supabase_uid, uniqueness: true, allow_nil: true
 
   def can_create_family?
@@ -42,5 +43,11 @@ class User < ApplicationRecord
     return unless password != password_confirmation
 
     errors.add(:password_confirmation, "がパスワードと一致しません")
+  end
+
+  def birthday_cannot_be_in_the_future
+    return unless birthday > Date.today
+
+    errors.add(:birthday, "を未来の日付にすることはできません")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,6 @@ class User < ApplicationRecord
   has_one :owned_family, class_name: 'Family', foreign_key: 'owner_id'
   has_one_attached :avatar
   has_many :diaries
-  # TODO: 将来的にユーザー情報削除機能を実装した場合に、以下の記述に変更する
-  # has_many :diaries, dependent: :nullify
   has_many :reactions
 
   attr_accessor :password, :password_confirmation
@@ -14,9 +12,6 @@ class User < ApplicationRecord
   validates :password_confirmation, presence: true, on: :create
   validate :password_match, on: :create
   validates :name, presence: true
-
-  # 招待時のロジックなどで、既に家族がいる場合はエラーにする
-  validate :must_not_belong_to_multiple_families, on: :create_membership
 
   def can_create_family?
     family_id.nil? && owned_family.nil?
@@ -31,7 +26,7 @@ class User < ApplicationRecord
       # 外部ストレージのURLを返す
       Rails.application.routes.url_helpers.url_for(avatar)
     else
-      # assets内などのデフォルト画像のパスを返す
+      # デフォルト画像のパスを返す
       ActionController::Base.helpers.asset_path('default-avatar.png')
     end
   end
@@ -42,11 +37,5 @@ class User < ApplicationRecord
     return unless password != password_confirmation
 
     errors.add(:password_confirmation, "がパスワードと一致しません")
-  end
-
-  def must_not_belong_to_multiple_families
-    return unless family_id.present?
-
-    errors.add(:family, "は既に登録済みです。他の家族に参加することはできません。")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,10 @@ class User < ApplicationRecord
   validates :email, presence: true,
                     uniqueness: { case_sensitive: false },
                     format: { with: URI::MailTo::EMAIL_REGEXP }
-  validates :password, presence: true, length: { minimum: 6 }, on: :create
+  validates :password, presence: true,
+                       format: { with: /\A(?=.*[a-zA-Z0-9])[!-~]+\z/,
+                                 message: 'は英数字のいずれかを必ず含む、英数字と半角記号のみにしてください' },
+length: { minimum: 6 }, on: :create
   validates :password_confirmation, presence: true, on: :create
   validate :password_match, on: :create
   validates :name, presence: true, length: { maximum: 50 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,11 @@ class User < ApplicationRecord
 
   attr_accessor :password, :password_confirmation
 
-  validates :email, presence: true, uniqueness: true
+before_save { self.email = self.email.downcase }
+
+  validates :email, presence: true,
+uniqueness: { case_sensitive: false },
+                    format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :password, presence: true, length: { minimum: 6 }, on: :create
   validates :password_confirmation, presence: true, on: :create
   validate :password_match, on: :create

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,9 @@ class User < ApplicationRecord
 
   validates :email, presence: true,
                     uniqueness: { case_sensitive: false },
-                    format: { with: URI::MailTo::EMAIL_REGEXP }
+                    length: { maximum: 500 }
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/ix
+  validates :email, format: { with: VALID_EMAIL_REGEX, message: 'の形式が正しくありません' }
   validates :password, presence: true,
                        format: { with: /\A(?=.*[a-zA-Z0-9])[!-~]+\z/,
                                  message: 'は英数字のいずれかを必ず含む、英数字と半角記号のみにしてください' },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,8 @@ class User < ApplicationRecord
                        length: { minimum: 6 }, on: :create
   validates :password_confirmation, presence: true, on: :create
   validate :password_match, on: :create
-  validates :name, presence: true, length: { maximum: 50 }
+  VALID_NAME_REGEX = /[\p{alnum}\p{hiragana}\p{katakana}\p{han}]/
+  validates :name, presence: true, length: { maximum: 50 }, format: { with: VALID_NAME_REGEX, message: 'を記号やスペースのみで入力することはできません' }
   validate :birthday_cannot_be_in_the_future
   validates :supabase_uid, uniqueness: true, allow_nil: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,7 @@ class User < ApplicationRecord
   VALID_NAME_REGEX = /[\p{alnum}\p{hiragana}\p{katakana}\p{han}]/
   validates :name, presence: true, length: { maximum: 50 }, format: { with: VALID_NAME_REGEX, message: 'を記号やスペースのみで入力することはできません' }
   validate :birthday_cannot_be_in_the_future
+  before_validation { self.supabase_uid = supabase_uid.presence }
   validates :supabase_uid, uniqueness: true, allow_nil: true
 
   def can_create_family?
@@ -52,6 +53,7 @@ class User < ApplicationRecord
   end
 
   def birthday_cannot_be_in_the_future
+    return if birthday.blank?
     return unless birthday > Date.today
 
     errors.add(:birthday, "を未来の日付にすることはできません")

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -67,8 +67,8 @@ FactoryBot.define do
       email { 'a' }
     end
 
-    trait :thousand_character_email do
-      email { 'a' * 500 + '@' + 'b' * 499 }
+    trait :too_long_email do
+      email { 'a' * 200 + '@' + 'b' * 300 }
     end
 
     trait :contain_blank_email do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
     end
 
     trait :only_full_width_symbol_name do
-      name { "！＠＃＄％＆（）＝＊＋ー「」？＞＜" }
+      name { "！＠＃＄％＆（）＝＊＋「」？＞＜" }
     end
 
     trait :mixed_half_width_and_full_width_character_name do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -52,20 +52,19 @@ RSpec.describe User, type: :model do
           user.valid?
           expect(user.errors.full_messages).to include("表示名を入力してください")
         end
-        # it '4. nameが51文字以上であるため無効' do
-        #   nameに文字数制限のバリデーションを付けること
-        #   user = build(:user, :too_long_name)
-        #   user.valid?
-        #   expect(user.errors.full_messages).to include("50文字以内で入力してください")
-        # end
+        it '4. nameが51文字以上であるため無効' do
+          user = build(:user, :too_long_name)
+          user.valid?
+          expect(user.errors.full_messages).to include("表示名は50文字以内で入力してください")
+        end
       end
 
-      # context 'C1. emailのバリデーションが有効：' do
-      #   it 'emailが大文字で入力・保存されても、DB上では小文字で保存されている' do
-      #     user = create(:user, email: 'TEST@EXAMPLE.COM')
-      #     expect(user.reload.email).to eq 'test@example.com'
-      #   end
-      # end
+      context 'C1. emailのバリデーションが有効：' do
+        it 'emailが大文字で入力・保存されても、DB上では小文字で保存されている' do
+          user = create(:user, email: 'TEST@EXAMPLE.COM')
+          expect(user.reload.email).to eq 'test@example.com'
+        end
+      end
 
       context 'C2. emailのバリデーションが無効：' do
         it 'emailが空であるため無効' do
@@ -125,13 +124,14 @@ RSpec.describe User, type: :model do
           user.valid?
           expect(user.errors.full_messages).to include("")
         end
+=end
         it 'emailのユーザー名の部分を大文字で登録すると、小文字として一意性が保たれるため無効' do
-          # emailに case_sensitive: false を設定し、エラーメッセージを確認すること
           create(:user, email: 'test@example.com')
           user = build(:user, email: 'TEST@EXAMPLE.COM')
-          user.valid
-          expect(user.errors.full_messages).to include("")
+          user.valid?
+          expect(user.errors.full_messages).to include("メールアドレスはすでに存在します")
         end
+=begin
         it '@前のユーザー名が記入されていないため無効' do
           user = build(:user, :except_username_from_email)
           user.valid?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -83,66 +83,62 @@ RSpec.describe User, type: :model do
           user.valid?
           expect(user.errors.full_messages).to include("メールアドレスはすでに存在します")
         end
-=begin
         it 'emailが1文字しか入力されていないため無効' do
           user = build(:user, :one_character_email)
           user.valid?
-          expect(user.errors.full_messages).to include("")
+          expect(user.errors.full_messages).to include("メールアドレスの形式が正しくありません")
         end
-        it 'emailが1000文字以上入力されたため無効' do
-          user = build(:user, :thousand_character_email)
+        it 'emailが501文字以上入力されたため無効' do
+          user = build(:user, :too_long_email)
           user.valid?
-          expect(user.errors.full_messages).to include("")
+          expect(user.errors[:email]).to contain_exactly("の形式が正しくありません", "は500文字以内で入力してください")
         end
         it 'emailに空白文字が含まれているため無効' do
           user = build(:user, :contain_blank_email)
           user.valid?
-          expect(user.errors.full_messages).to include("")
+          expect(user.errors.full_messages).to include("メールアドレスの形式が正しくありません")
         end
         it 'emailが全角文字のみで入力されたため無効' do
           user = build(:user, :only_full_width_character_email)
           user.valid?
-          expect(user.errors.full_messages).to include("")
+          expect(user.errors.full_messages).to include("メールアドレスの形式が正しくありません")
         end
         it 'emailが全角文字を含んでいるため無効' do
           user = build(:user, :contain_full_width_character_email)
           user.valid?
-          expect(user.errors.full_messages).to include("")
+          expect(user.errors.full_messages).to include("メールアドレスの形式が正しくありません")
         end
         it 'emailに@が入っていないため無効' do
           user = build(:user, :except_atmark_from_email)
           user.valid?
-          expect(user.errors.full_messages).to include("")
+          expect(user.errors.full_messages).to include("メールアドレスの形式が正しくありません")
         end
         it 'emailが半角記号のみ入力されたため無効' do
           user = build(:user, :only_half_width_symbol_email)
           user.valid?
-          expect(user.errors.full_messages).to include("")
+          expect(user.errors.full_messages).to include("メールアドレスの形式が正しくありません")
         end
         it 'emailが@、_、.以外の半角記号を含んでいるため無効' do
           user = build(:user, :contain_half_width_symbol_email)
           user.valid?
-          expect(user.errors.full_messages).to include("")
+          expect(user.errors.full_messages).to include("メールアドレスの形式が正しくありません")
         end
-=end
         it 'emailのユーザー名の部分を大文字で登録すると、小文字として一意性が保たれるため無効' do
           create(:user, email: 'test@example.com')
           user = build(:user, email: 'TEST@EXAMPLE.COM')
           user.valid?
           expect(user.errors.full_messages).to include("メールアドレスはすでに存在します")
         end
-=begin
         it '@前のユーザー名が記入されていないため無効' do
           user = build(:user, :except_username_from_email)
           user.valid?
-          expect(user.errors.full_messages).to include("")
+          expect(user.errors.full_messages).to include("メールアドレスの形式が正しくありません")
         end
         it '@後のドメイン名が記入されていないため無効' do
           user = build(:user, :except_domain_from_email)
           user.valid?
-          expect(user.errors.full_messages).to include("")
+          expect(user.errors.full_messages).to include("メールアドレスの形式が正しくありません")
         end
-=end
       end
 
       context 'D1. passwordのバリデーションが有効：' do
@@ -170,28 +166,26 @@ RSpec.describe User, type: :model do
           user.valid?
           expect(user.errors.full_messages).to include("パスワードを入力してください")
         end
-=begin
         it 'passwordが空白文字を含むため無効' do
           user = build(:user, :contain_blank_password)
-          p user.valid?
-          expect(user.errors.full_messages).to include("")
+          user.valid?
+          expect(user.errors.full_messages).to include("パスワードは英数字のいずれかを必ず含む、英数字と半角記号のみにしてください")
         end
         it 'passwordが全角文字のみ入力されているため無効' do
           user = build(:user, :only_full_width_character_password)
-          p user.valid?
-          expect(user.errors.full_messages).to include("")
+          user.valid?
+          expect(user.errors.full_messages).to include("パスワードは英数字のいずれかを必ず含む、英数字と半角記号のみにしてください")
         end
         it 'passwordに全角文字が含まれているため無効' do
           user = build(:user, :contain_full_width_character_password)
-          p user.valid?
-          expect(user.errors.full_messages).to include("")
+          user.valid?
+          expect(user.errors.full_messages).to include("パスワードは英数字のいずれかを必ず含む、英数字と半角記号のみにしてください")
         end
         it 'passwordが半角記号のみ入力されているため無効' do
           user = build(:user, :only_half_width_symbol_password)
-          p user.valid?
-          expect(user.errors.full_messages).to include("")
+          user.valid?
+          expect(user.errors.full_messages).to include("パスワードは英数字のいずれかを必ず含む、英数字と半角記号のみにしてください")
         end
-=end
       end
 
       context 'E1. password_confirmationのバリデーションが有効：' do
@@ -219,13 +213,11 @@ RSpec.describe User, type: :model do
       end
 
       context 'F. birthdayのバリデーションが無効：' do
-=begin
         it 'birthdayが未来の日付のため無効' do
           user = build(:user, :future_birthday)
-          p user.valid?
-          expect(user.errors.full_messages).to include("")
+          user.valid?
+          expect(user.errors.full_messages).to include("誕生日を未来の日付にすることはできません")
         end
-=end
       end
 
       context 'G1. supabase_uidのバリデーションが有効：' do
@@ -238,15 +230,12 @@ RSpec.describe User, type: :model do
       end
 
       context 'G2. supabase_uidのバリデーションが無効：' do
-=begin
         it '既に存在するsupabase_uidのデータと被っているため無効' do
-          # uniqueness : true を付与すべきなのかどうかAIに相談
           first_user = create(:user)
           user = build(:user, supabase_uid: first_user.supabase_uid)
           user.valid?
-          expect(user.errors.full_messages).to include("")
+          expect(user.errors.full_messages).to include("Supabase uidはすでに存在します")
         end
-=end
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,16 +22,10 @@ RSpec.describe User, type: :model do
         it '4. nameが半角文字のみであり有効' do
           expect(build(:user, :only_half_width_character_name)).to be_valid
         end
-        it '5. nameが半角記号のみであり有効' do
-          expect(build(:user, :only_half_width_symbol_name)).to be_valid
-        end
-        it '6. nameが全角記号のみであり有効' do
-          expect(build(:user, :only_full_width_symbol_name)).to be_valid
-        end
-        it '7. nameが全角文字と半角文字を含んでおり有効' do
+        it '5. nameが全角文字と半角文字を含んでおり有効' do
           expect(build(:user, :mixed_half_width_and_full_width_character_name)).to be_valid
         end
-        it '8. nameが全角文字と半角記号を含んでおり有効' do
+        it '6. nameが全角文字と半角記号を含んでおり有効' do
           expect(build(:user, :contain_half_width_symbol_name)).to be_valid
         end
       end
@@ -51,90 +45,102 @@ RSpec.describe User, type: :model do
           user = build(:user, :blank_character_name)
           user.valid?
           expect(user.errors.full_messages).to include("表示名を入力してください")
+          expect(user.errors.full_messages).to include("表示名を記号やスペースのみで入力することはできません")
         end
         it '4. nameが51文字以上であるため無効' do
           user = build(:user, :too_long_name)
           user.valid?
           expect(user.errors.full_messages).to include("表示名は50文字以内で入力してください")
         end
+        it '5. nameが半角記号のみであり無効' do
+          user = build(:user, :only_half_width_symbol_name)
+          user.valid?
+          expect(user.errors.full_messages).to include("表示名を記号やスペースのみで入力することはできません")
+        end
+        it '6. nameが全角記号のみであり無効' do
+          user = build(:user, :only_full_width_symbol_name)
+          user.valid?
+          expect(user.errors.full_messages).to include("表示名を記号やスペースのみで入力することはできません")
+        end
       end
 
       context 'C1. emailのバリデーションが有効：' do
-        it 'emailが大文字で入力・保存されても、DB上では小文字で保存されている' do
+        it '1. emailが大文字で入力・保存されても、DB上では小文字で保存されている' do
           user = create(:user, email: 'TEST@EXAMPLE.COM')
           expect(user.reload.email).to eq 'test@example.com'
         end
       end
 
       context 'C2. emailのバリデーションが無効：' do
-        it 'emailが空であるため無効' do
+        it '1. emailが空であるため無効' do
           user = build(:user, :no_email)
           user.valid?
           expect(user.errors.full_messages).to include("メールアドレスを入力してください")
         end
-        it 'emailがnilであるため無効' do
+        it '2. emailがnilであるため無効' do
           user = build(:user, :nil_email)
           user.valid?
           expect(user.errors.full_messages).to include("メールアドレスを入力してください")
         end
-        it '既に存在するemailのデータと被っているため無効' do
+        it '3. 既に存在するemailのデータと被っているため無効' do
           first_user = create(:user)
           user = build(:user, email: first_user.email)
           user.valid?
           expect(user.errors.full_messages).to include("メールアドレスはすでに存在します")
         end
-        it 'emailが1文字しか入力されていないため無効' do
+        it '4. emailが1文字しか入力されていないため無効' do
           user = build(:user, :one_character_email)
           user.valid?
           expect(user.errors.full_messages).to include("メールアドレスの形式が正しくありません")
         end
-        it 'emailが501文字以上入力されたため無効' do
+        it '5. emailが501文字以上入力されたため無効' do
           user = build(:user, :too_long_email)
           user.valid?
-          expect(user.errors[:email]).to contain_exactly("の形式が正しくありません", "は500文字以内で入力してください")
+          expect(user.errors.full_messages).to include("メールアドレスは500文字以内で入力してください")
+          expect(user.errors.full_messages).to include("メールアドレスの形式が正しくありません")
         end
-        it 'emailに空白文字が含まれているため無効' do
+        it '6. emailに空白文字が含まれているため無効' do
           user = build(:user, :contain_blank_email)
           user.valid?
           expect(user.errors.full_messages).to include("メールアドレスの形式が正しくありません")
         end
-        it 'emailが全角文字のみで入力されたため無効' do
+        it '7. emailが全角文字のみで入力されたため無効' do
           user = build(:user, :only_full_width_character_email)
           user.valid?
           expect(user.errors.full_messages).to include("メールアドレスの形式が正しくありません")
         end
-        it 'emailが全角文字を含んでいるため無効' do
+        it '8. emailが全角文字を含んでいるため無効' do
           user = build(:user, :contain_full_width_character_email)
           user.valid?
           expect(user.errors.full_messages).to include("メールアドレスの形式が正しくありません")
         end
-        it 'emailに@が入っていないため無効' do
+        it '9. emailに@が入っていないため無効' do
           user = build(:user, :except_atmark_from_email)
           user.valid?
           expect(user.errors.full_messages).to include("メールアドレスの形式が正しくありません")
         end
-        it 'emailが半角記号のみ入力されたため無効' do
+        it '10. emailが半角記号のみ入力されたため無効' do
           user = build(:user, :only_half_width_symbol_email)
           user.valid?
           expect(user.errors.full_messages).to include("メールアドレスの形式が正しくありません")
         end
-        it 'emailが@、_、.以外の半角記号を含んでいるため無効' do
+        it '11. emailが@、_、.以外の半角記号を含んでいるため無効' do
           user = build(:user, :contain_half_width_symbol_email)
           user.valid?
           expect(user.errors.full_messages).to include("メールアドレスの形式が正しくありません")
         end
-        it 'emailのユーザー名の部分を大文字で登録すると、小文字として一意性が保たれるため無効' do
+        it '12. emailのユーザー名の部分を大文字で登録すると、小文字として一意性が保たれるため無効' do
           create(:user, email: 'test@example.com')
           user = build(:user, email: 'TEST@EXAMPLE.COM')
           user.valid?
           expect(user.errors.full_messages).to include("メールアドレスはすでに存在します")
         end
-        it '@前のユーザー名が記入されていないため無効' do
+        it '13. @前のユーザー名が記入されていないため無効' do
           user = build(:user, :except_username_from_email)
           user.valid?
           expect(user.errors.full_messages).to include("メールアドレスの形式が正しくありません")
         end
-        it '@後のドメイン名が記入されていないため無効' do
+        it '14. @後のドメイン名が記入されていないため無効' do
           user = build(:user, :except_domain_from_email)
           user.valid?
           expect(user.errors.full_messages).to include("メールアドレスの形式が正しくありません")
@@ -142,46 +148,46 @@ RSpec.describe User, type: :model do
       end
 
       context 'D1. passwordのバリデーションが有効：' do
-        it 'passwordが6文字であるため有効' do
+        it '1. passwordが6文字であるため有効' do
           expect(build(:user, :six_character_password)).to be_valid
         end
-        it 'passwordに半角記号が含まれているため有効' do
+        it '2. passwordに半角記号が含まれているため有効' do
           expect(build(:user, :contain_half_width_symbol_password)).to be_valid
         end
       end
 
       context 'D2. passwordのバリデーションが無効：' do
-        it 'passwordが6文字未満であるため無効' do
+        it '1. passwordが6文字未満であるため無効' do
           user = build(:user, :too_short_password)
           user.valid?
           expect(user.errors.full_messages).to include("パスワードは6文字以上で入力してください")
         end
-        it 'passwordが空白であるため無効' do
+        it '2. passwordが空白であるため無効' do
           user = build(:user, :blank_character_password)
           user.valid?
           expect(user.errors.full_messages).to include("パスワードを入力してください")
         end
-        it 'passwordがnilであるため無効' do
+        it '3. passwordがnilであるため無効' do
           user = build(:user, :nil_password)
           user.valid?
           expect(user.errors.full_messages).to include("パスワードを入力してください")
         end
-        it 'passwordが空白文字を含むため無効' do
+        it '4. passwordが空白文字を含むため無効' do
           user = build(:user, :contain_blank_password)
           user.valid?
           expect(user.errors.full_messages).to include("パスワードは英数字のいずれかを必ず含む、英数字と半角記号のみにしてください")
         end
-        it 'passwordが全角文字のみ入力されているため無効' do
+        it '5. passwordが全角文字のみ入力されているため無効' do
           user = build(:user, :only_full_width_character_password)
           user.valid?
           expect(user.errors.full_messages).to include("パスワードは英数字のいずれかを必ず含む、英数字と半角記号のみにしてください")
         end
-        it 'passwordに全角文字が含まれているため無効' do
+        it '6. passwordに全角文字が含まれているため無効' do
           user = build(:user, :contain_full_width_character_password)
           user.valid?
           expect(user.errors.full_messages).to include("パスワードは英数字のいずれかを必ず含む、英数字と半角記号のみにしてください")
         end
-        it 'passwordが半角記号のみ入力されているため無効' do
+        it '7. passwordが半角記号のみ入力されているため無効' do
           user = build(:user, :only_half_width_symbol_password)
           user.valid?
           expect(user.errors.full_messages).to include("パスワードは英数字のいずれかを必ず含む、英数字と半角記号のみにしてください")
@@ -189,23 +195,23 @@ RSpec.describe User, type: :model do
       end
 
       context 'E1. password_confirmationのバリデーションが有効：' do
-        it 'password_confirmationがpasswordと一致しているため有効' do
+        it '1. password_confirmationがpasswordと一致しているため有効' do
           expect(build(:user, password: 'pass123word', password_confirmation: 'pass123word')).to be_valid
         end
       end
 
       context 'E2. password_confirmationのバリデーションが無効：' do
-        it 'password_confirmationが未入力のため無効' do
+        it '1. password_confirmationが未入力のため無効' do
           user = build(:user, :no_password_confirmation)
           user.valid?
           expect(user.errors.details[:password_confirmation]).to include({:error => :blank})
         end
-        it 'password_confirmationがnilのため無効' do
+        it '2. password_confirmationがnilのため無効' do
           user = build(:user, :nil_password_confirmation)
           user.valid?
           expect(user.errors.details[:password_confirmation]).to include({:error => :blank})
         end
-        it 'password_confirmationがpasswordと不一致のため無効' do
+        it '3. password_confirmationがpasswordと不一致のため無効' do
           user = build(:user, password_confirmation: "passwords" )
           user.valid?
           expect(user.errors.full_messages).to include("パスワード（確認）がパスワードと一致しません")
@@ -213,7 +219,7 @@ RSpec.describe User, type: :model do
       end
 
       context 'F. birthdayのバリデーションが無効：' do
-        it 'birthdayが未来の日付のため無効' do
+        it '1. birthdayが未来の日付のため無効' do
           user = build(:user, :future_birthday)
           user.valid?
           expect(user.errors.full_messages).to include("誕生日を未来の日付にすることはできません")
@@ -221,16 +227,16 @@ RSpec.describe User, type: :model do
       end
 
       context 'G1. supabase_uidのバリデーションが有効：' do
-        it 'supabase_uidが空白のため有効' do
+        it '1. supabase_uidが空白のため有効' do
           expect(build(:user, :no_supabase_uid)).to be_valid
         end
-        it 'supabase_uidがnilのため有効' do
+        it '2. supabase_uidがnilのため有効' do
           expect(build(:user, :nil_supabase_uid)).to be_valid
         end
       end
 
       context 'G2. supabase_uidのバリデーションが無効：' do
-        it '既に存在するsupabase_uidのデータと被っているため無効' do
+        it '1. 既に存在するsupabase_uidのデータと被っているため無効' do
           first_user = create(:user)
           user = build(:user, supabase_uid: first_user.supabase_uid)
           user.valid?
@@ -243,11 +249,11 @@ RSpec.describe User, type: :model do
       context 'A. 家族グループへの所属' do
         let(:user) { create(:user) }
         let(:family) { create(:family, owner_id: user.id) }
-        it 'Userのfamily_idに、存在するFamilyのIDを設定し、紐づけられたFamilyのオブジェクトが返ってくる' do
+        it '1. Userのfamily_idに、存在するFamilyのIDを設定し、紐づけられたFamilyのオブジェクトが返ってくる' do
           user.family_id = family.id
           expect(user.family).to eq family
         end
-        it 'Userのfamily_idがnilであっても有効となる' do
+        it '2. Userのfamily_idがnilであっても有効となる' do
           expect(build(:user, family_id: nil)).to be_valid
         end
       end
@@ -255,10 +261,10 @@ RSpec.describe User, type: :model do
       context 'B. 管理者ユーザーとしての家族グループの紐づけ' do
         let!(:user) { create(:user) }
         let!(:family) { create(:family, owner_id: user.id) }
-        it 'owned_familyでUserが管理者ユーザーとなっているFamilyのオブジェクトが返ってくる' do
+        it '1. owned_familyでUserが管理者ユーザーとなっているFamilyのオブジェクトが返ってくる' do
           expect(user.owned_family).to eq family
         end
-        it 'いずれの家族グループの管理者ユーザーでない場合、owned_familyでnilが返ってくる' do
+        it '2. いずれの家族グループの管理者ユーザーでない場合、owned_familyでnilが返ってくる' do
           user = create(:user)
           expect(user.owned_family).to be_nil
         end


### PR DESCRIPTION
## 概要
`User`モデルにバリデーションを追加した

## 関連issue
#218 

## やったこと
 - `User`モデルにバリデーションを追加
	 - `email`の一意性制約に`case_sensitive: false`を追記
	 - `email`の形式バリデーションを追加
	 - `supabase_uid`に一意性制約を追加（`nil`を許容）
	 - `name`に文字数制限（50文字まで）をかける
	 - `birthday`の未来日付チェックを追加
	 - `password`の文字種制限（全角文字・空白の禁止）を追加
	 - `name`の記号のみ入力を禁止
 - テストコードを追加
	 - 既に作成していたテストのコメントアウトを解除
	 - `name`を記号のみ入力した場合を無効に変更

## テスト／完了確認
 - [x] `RSpec`を実行、`User`モデルのテスト通過