### PR TITLE
Fix: #221 AIコードレビューで指摘された部分を修正

### DIFF
--- a/.github/workflows/code-rabbit.yml
+++ b/.github/workflows/code-rabbit.yml
@@ -6,7 +6,11 @@ permissions:
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
 
 concurrency:
   group:
@@ -25,24 +29,13 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         with:
           debug: false
-          language: ja-JP
           review_simple_changes: false
           review_comment_lgtm: false
-          openai_light_model: "gpt-4o-mini"
+          openai_timeout_ms: 900000
+          language: ja-JP
           summarize: |
             最終的な回答を `markdown` フォーマットで以下の内容で書いてください:
             - 高レベルの要約（特定のファイルではなく、全体的な変更点についてのコメント日本語200文字以内)
             - ファイルとその要約のtableを書くこと
             - 同じような変更点のあるファイルをスペースを節約するために、同じような変更を持つファイルを1つの行にまとめてよい
             この要約は、GitHub の PullRequest にコメントとして追加されるので、追加コメントは避けること
-          summarize_release_notes: |
-            この PullRequest のために `markdown` フォーマットで簡潔なリリースノートを作成すること。
-            コードの目的とユーザーストーリーに焦点を当てること。
-            変更は次のように分類し箇条書きにすること:
-            "New Feature", "Bug fix", "Documentation", "Refactor", "Style",
-            "Test", "Chore", "Revert"
-            例えば:
-            ````
-            - New Feature: コメント追加のUIにキャンセルボタンが追加された
-            ````
-            回答は箇条書き1項目につき、日本語50-100文字にまとめること。

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -16,7 +16,9 @@ class PasswordsController < ApplicationController
   end
 
   # パスワード変更画面
-  def edit; end
+  def edit
+    @user = User.new
+  end
 
   # パスワード更新実行
   def update
@@ -25,14 +27,20 @@ class PasswordsController < ApplicationController
     # 明示的に params から取る
     access_token = params[:access_token].presence || cookies[:rails_access_token]
 
-    # バリデーション
-    if new_password.blank? || new_password != password_confirmation
-      flash.now[:alert] = "パスワードが一致しないか、入力されていません"
+    if access_token.blank?
+      flash.now[:alert] = "トークンが見つかりません。メールのリンクからやり直してください"
       return render :edit, status: :unprocessable_entity
     end
 
-    if access_token.blank?
-      flash.now[:alert] = "トークンが見つかりません。メールのリンクからやり直してください"
+    # バリデーション用の User インスタンスを作成
+    @user = User.new(
+      password: new_password,
+      password_confirmation: password_confirmation
+    )
+    @user.updating_password = true
+
+    # User モデルのバリデーションを実行
+    unless @user.valid?
       return render :edit, status: :unprocessable_entity
     end
 

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -40,9 +40,7 @@ class PasswordsController < ApplicationController
     @user.updating_password = true
 
     # User モデルのバリデーションを実行
-    unless @user.valid?
-      return render :edit, status: :unprocessable_entity
-    end
+    return render :edit, status: :unprocessable_entity unless @user.valid?
 
     response = update_supabase_password(access_token, new_password)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,22 +6,28 @@ class User < ApplicationRecord
   has_many :reactions
 
   attr_accessor :password, :password_confirmation
+  attr_accessor :updating_password
 
   before_save { self.email = email.downcase }
 
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/ix
   validates :email, presence: true,
                     uniqueness: { case_sensitive: false },
-                    length: { maximum: 500 }
-  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/ix
-  validates :email, format: { with: VALID_EMAIL_REGEX, message: 'の形式が正しくありません' }
+                    length: { maximum: 500 },
+                    format: { with: VALID_EMAIL_REGEX, message: 'の形式が正しくありません' },
+                    unless: :updating_password
   validates :password, presence: true,
                        format: { with: /\A(?=.*[a-zA-Z0-9])[!-~]+\z/,
                                  message: 'は英数字のいずれかを必ず含む、英数字と半角記号のみにしてください' },
-                       length: { minimum: 6 }, on: :create
-  validates :password_confirmation, presence: true, on: :create
-  validate :password_match, on: :create
+                       length: { minimum: 6 },
+                       if: :should_validate_password?
+  validates :password_confirmation, presence: true, if: :should_validate_password?
+  validate :password_match, if: :should_validate_password?
   VALID_NAME_REGEX = /[\p{alnum}\p{hiragana}\p{katakana}\p{han}]/
-  validates :name, presence: true, length: { maximum: 50 }, format: { with: VALID_NAME_REGEX, message: 'を記号やスペースのみで入力することはできません' }
+  validates :name, presence: true,
+                   length: { maximum: 50 },
+                   format: { with: VALID_NAME_REGEX, message: 'を記号やスペースのみで入力することはできません' },
+                   unless: :updating_password
   validate :birthday_cannot_be_in_the_future
   before_validation { self.supabase_uid = supabase_uid.presence }
   validates :supabase_uid, uniqueness: true, allow_nil: true
@@ -50,6 +56,10 @@ class User < ApplicationRecord
     return unless password != password_confirmation
 
     errors.add(:password_confirmation, "がパスワードと一致しません")
+  end
+
+  def should_validate_password?
+    (new_record? && supabase_uid.blank?) || updating_password
   end
 
   def birthday_cannot_be_in_the_future

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,8 +5,7 @@ class User < ApplicationRecord
   has_many :diaries
   has_many :reactions
 
-  attr_accessor :password, :password_confirmation
-  attr_accessor :updating_password
+  attr_accessor :password, :password_confirmation, :updating_password
 
   before_save { self.email = email.downcase }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,7 +63,7 @@ class User < ApplicationRecord
   end
 
   def updating_password?
-    ActiveModel::Type::Boolean.new.cast(`@updating_password`)
+    ActiveModel::Type::Boolean.new.cast(@updating_password)
   end
 
   def birthday_cannot_be_in_the_future

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,8 @@ class User < ApplicationRecord
   has_many :diaries
   has_many :reactions
 
-  attr_accessor :password, :password_confirmation, :updating_password
+  attr_accessor :password, :password_confirmation
+  attr_writer :updating_password
 
   before_save { self.email = email.downcase }
 
@@ -14,7 +15,7 @@ class User < ApplicationRecord
                     uniqueness: { case_sensitive: false },
                     length: { maximum: 500 },
                     format: { with: VALID_EMAIL_REGEX, message: 'の形式が正しくありません' },
-                    unless: :updating_password
+                    unless: :updating_password?
   validates :password, presence: true,
                        format: { with: /\A(?=.*[a-zA-Z0-9])[!-~]+\z/,
                                  message: 'は英数字のいずれかを必ず含む、英数字と半角記号のみにしてください' },
@@ -26,7 +27,7 @@ class User < ApplicationRecord
   validates :name, presence: true,
                    length: { maximum: 50 },
                    format: { with: VALID_NAME_REGEX, message: 'を記号やスペースのみで入力することはできません' },
-                   unless: :updating_password
+                   unless: :updating_password?
   validate :birthday_cannot_be_in_the_future
   before_validation { self.supabase_uid = supabase_uid.presence }
   validates :supabase_uid, uniqueness: true, allow_nil: true
@@ -58,7 +59,11 @@ class User < ApplicationRecord
   end
 
   def should_validate_password?
-    (new_record? && supabase_uid.blank?) || updating_password
+    (new_record? && supabase_uid.blank?) || updating_password?
+  end
+
+  def updating_password?
+    ActiveModel::Type::Boolean.new.cast(`@updating_password`)
   end
 
   def birthday_cannot_be_in_the_future

--- a/app/views/mypages/edit.html.erb
+++ b/app/views/mypages/edit.html.erb
@@ -6,6 +6,9 @@
   <div class="w-full max-w-md bg-amber-50/90 rounded-3xl shadow-md p-6 space-y-7 border border-amber-200">
     <div id="user_form">
     <%= form_with model: @user, url: mypage_path, method: :patch, data: { turbo: false }, local: true, class: "space-y-6" do |f| %>
+      <%# エラー表示 %>
+      <%= render 'shared/error_messages', object: f.object %>
+      
       <div class="flex flex-col items-center space-y-3 mb-8">
         <div class="relative">
           <div class="size-24 rounded-full bg-lime-200 overflow-hidden shadow-xs">

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -9,15 +9,7 @@
       <%= hidden_field_tag :access_token, params[:access_token] || cookies[:rails_access_token], id: "hidden_access_token" %>
 
       <%# エラー表示 %>
-      <% if @user&.errors&.any? %>
-        <div class="bg-red-100 border border-red-400 text-red-700 pl-8 py-2 mb-4 rounded-md pointer-events-auto">
-          <ul class="list-disc">
-          <% @user.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
-          <% end %>
-          </ul>
-        </div>
-      <% end %>
+      <%= render 'shared/error_messages', object: @user %>
       
       <div>
         <%= f.label :password, "新しいパスワード", class: "block text-base font-semibold text-amber-800 mb-2" %>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -7,15 +7,27 @@
     <%= form_with url: password_update_path, method: :patch, local: true, id: "password-reset-form", data: { turbo: false }, class: "space-y-6" do |f| %>
       <%# URLハッシュから取得したトークンを隠しフィールドで保持する %>
       <%= hidden_field_tag :access_token, params[:access_token] || cookies[:rails_access_token], id: "hidden_access_token" %>
+
+      <%# エラー表示 %>
+      <% if @user&.errors&.any? %>
+        <div class="bg-red-100 border border-red-400 text-red-700 pl-8 py-2 mb-4 rounded-md pointer-events-auto">
+          <ul class="list-disc">
+          <% @user.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+          </ul>
+        </div>
+      <% end %>
       
-        <div>
-          <%= f.label :password, "新しいパスワード", class: "block text-base font-semibold text-amber-800 mb-2" %>
-          <%= f.password_field :password, required: true, minlength: 6, class: "w-full p-3 border border-amber-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent transition duration-200 ease-in-out bg-white text-lime-800 shadow-sm", placeholder: "入力してください" %>
-        </div>
-        <div>
-          <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "block text-base font-semibold text-amber-800 mb-2" %>
-          <%= f.password_field :password_confirmation, required: true, class: "w-full p-3 border border-amber-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent transition duration-200 ease-in-out bg-white text-lime-800 shadow-sm", placeholder: "もう一度入力してください" %>
-        </div>
+      <div>
+        <%= f.label :password, "新しいパスワード", class: "block text-base font-semibold text-amber-800 mb-2" %>
+        <%= f.password_field :password, required: true, minlength: 6, class: "w-full p-3 border border-amber-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent transition duration-200 ease-in-out bg-white text-lime-800 shadow-sm", placeholder: "入力してください" %>
+      </div>
+      <div>
+        <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "block text-base font-semibold text-amber-800 mb-2" %>
+        <%= f.password_field :password_confirmation, required: true, class: "w-full p-3 border border-amber-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent transition duration-200 ease-in-out bg-white text-lime-800 shadow-sm", placeholder: "もう一度入力してください" %>
+      </div>
+
       <%= f.submit t('helpers.submit.password.update'), class: "w-full bg-rose-500 hover:bg-rose-600 text-white font-bold py-3 px-6 rounded-full shadow-lg transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-opacity-50 tracking-wide mt-2" %>
     <% end %>
   </div>

--- a/db/migrate/20260313061211_add_unique_index_to_users_email.rb
+++ b/db/migrate/20260313061211_add_unique_index_to_users_email.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToUsersEmail < ActiveRecord::Migration[7.1]
+  def change
+    add_index :users, 'LOWER(email)', unique: true, name: 'index_users_on_lower_email'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_01_26_020001) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_13_061211) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -109,6 +109,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_26_020001) do
     t.datetime "updated_at", null: false
     t.string "supabase_uid"
     t.bigint "family_id"
+    t.index "lower((email)::text)", name: "index_users_on_lower_email", unique: true
     t.index ["family_id"], name: "index_users_on_family_id"
     t.index ["supabase_uid"], name: "index_users_on_supabase_uid", unique: true
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     password_confirmation { password }
     name { '名前太郎' }
     birthday { '1999-01-01' }
-    sequence(:supabase_uid) { "supabase_uid_test#{_1}" }
 
     trait :no_name do
       name { '' }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe User, type: :model do
 
       context 'G2. supabase_uidのバリデーションが無効：' do
         it '1. 既に存在するsupabase_uidのデータと被っているため無効' do
-          first_user = create(:user)
+          first_user = create(:user, supabase_uid: 'supabase_uid')
           user = build(:user, supabase_uid: first_user.supabase_uid)
           user.valid?
           expect(user.errors.full_messages).to include("Supabase uidはすでに存在します")


### PR DESCRIPTION
## 概要
CodeRabbitによるAIコードレビューで指摘を受けた部分について修正を行った

## 関連issue
#221
#220 ：（コードレビューはこちらにあり）

## やったこと
 - `users`テーブルの`email`カラムに一意制約を付与
 - 新規登録時とパスワード更新時のパスワードのバリデーションチェック設定
	 - `User`モデルに`should_validate_password?`メソッドを追加し、そこで新規登録時またはパスワード更新時であるかどうかを判断
	 - `User`モデルに`updating_password`という`attr_accessor`を定義し、パスワード更新時にこのフラグを立てる（`true`を渡す）
	 - パスワード更新時のロジックなどを修正
		 - `PasswordsController`の`edit`・`update`アクションで`User`のインスタンスを作成し、バリデーションチェックを行うロジックに変更
		 - `update`アクション内で`updating_password`に`true`を渡し、フラグを立てる
		 - `app/views/passwords/edit.html.erb`内にバリデーションエラーメッセージを表示する部分を追加
 - `app/views/mypages/edit.html.erb`内にバリデーションエラーメッセージを表示する部分を追加
 - テスト：`User`のFactoryで`supabase_uid`に値を格納しない（基本的に`nil`にする）ようにした

## テスト／完了確認
 - [x] `db/schema.rb`で`email`に一意制約が欠けられていることを確認
 - [x] `User`モデルのテストを実施し、全て通ることを確認
 - [x] パスワードの更新を試し、適切にバリデーションチェックがなされ、通過した場合にパスワード変更ができることを確認

## 備考
たまたま `app/views/mypages/edit.html.erb` 内でバリデーションエラーメッセージが表示されないことに気づいたので修正対応した