### PR TITLE
Add: #225 `Family`モデルの`name`にバリデーションを追加

### DIFF
--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -4,5 +4,17 @@ class Family < ApplicationRecord
   has_many :children, dependent: :destroy
   has_many :diaries, dependent: :destroy
 
-  validates :name, length: { in: 1..50 }
+  before_validation :strip_whitespace
+  validates :name, presence: true,
+                   length: { in: 1..50 },
+                   format: {
+                     with: /\A[ぁ-んァ-ヶー一-龠々a-zA-Z0-9\s\-()（）・]+\z/,
+                     message: 'は日本語、英数字、スペース、ハイフン、カッコ、中点のみ使用できます'
+                   }
+
+  private
+
+  def strip_whitespace
+    self.name = name&.strip
+  end
 end

--- a/spec/factories/families.rb
+++ b/spec/factories/families.rb
@@ -25,9 +25,5 @@ FactoryBot.define do
     trait :fifty_one_characters_name do
       name { 'a' * 51 }
     end
-
-    trait :regular_string_name do
-      name { '家族ファミリーfamily123４５６' }
-    end
   end
 end

--- a/spec/models/family_spec.rb
+++ b/spec/models/family_spec.rb
@@ -18,31 +18,50 @@ RSpec.describe Family, type: :model do
           expect(build(:family, :fifty_characters_name, owner: user)).to be_valid
         end
         it 'nameが通常の文字列で構成されている場合、有効であること' do
-          expect(build(:family, :regular_string_name, owner: user)).to be_valid
+          expect(build(:family, name: '家族ファミリーFamily123', owner: user)).to be_valid
+        end
+        it 'nameに日本語が使用できること' do
+          expect(build(:family, name: '田中家', owner: user)).to be_valid
+        end
+        it 'nameに英数字が使用できること' do
+          expect(build(:family, name: 'Tanaka Family 2024', owner: user)).to be_valid
+        end
+        it 'nameにハイフンが使用できること' do
+          expect(build(:family, name: '田中-佐藤家', owner: user)).to be_valid
+        end
+        it 'nameにカッコが使用できること' do
+          expect(build(:family, name: '田中家（東京）', owner: user)).to be_valid
+        end
+        it 'nameに中点が使用できること' do
+          expect(build(:family, name: '田中・佐藤家', owner: user)).to be_valid
         end
       end
 
       context 'B2. nameのバリデーションが無効' do
-        it 'nameが空であるため無効' do
+        it 'nameが空であるため無効であること' do
           family = build(:family, :no_name, owner: user)
           expect(family).to be_invalid
           expect(family.errors.full_messages).to include("家族（グループ）名は1文字以上で入力してください")
         end
-        it 'nameがnilであるため無効' do
+        it 'nameがnilであるため無効であること' do
           family = build(:family, :nil_name, owner: user)
           expect(family).to be_invalid
           expect(family.errors.full_messages).to include("家族（グループ）名は1文字以上で入力してください")
         end
-        # it 'nameが空白文字のみであるため無効' do
-        # 空文字を弾くバリデーションを追加すること
-        #   family = build(:family, :blank_name, owner: user)
-        #   expect(family).to be_invalid
-        #   expect(family.errors.full_messages).to include("家族（グループ）名は1文字以上で入力してください")
-        # end
-        it 'nameが51文字以上であるため無効' do
+        it 'nameが空白文字のみであるため無効であること' do
+          family = build(:family, :blank_name, owner: user)
+          expect(family).to be_invalid
+          expect(family.errors.full_messages).to include("家族（グループ）名は1文字以上で入力してください")
+        end
+        it 'nameが51文字以上であるため無効であること' do
           family = build(:family, :fifty_one_characters_name, owner: user)
           expect(family).to be_invalid
           expect(family.errors.full_messages).to include("家族（グループ）名は50文字以内で入力してください")
+        end
+        it '特殊記号を使用しているため無効であること' do
+          family = build(:family, name: '田中家<script>', owner: user)
+          expect(family).to be_invalid
+          expect(family.errors.full_messages).to include('家族（グループ）名は日本語、英数字、スペース、ハイフン、カッコ、中点のみ使用できます')
         end
       end
     end


### PR DESCRIPTION
## 概要
`Family`モデルの`name`にバリデーションを追加

## 関連issue
#225 

## やったこと
 - `Family`モデルの`name`に以下のバリデーションを追加
	 - `presense: true`
	 - ```
            format: {
              with: /\A[ぁ-んァ-ヶー一-龠々a-zA-Z0-9\s\-()（）・]+\z/,
              message: 'は日本語、英数字、スペース、ハイフン、カッコ、中点のみ使用できます'
            }
	    ```
 - バリデーションチェックが有効であるかどうかのテストケースを`spec/models/family_spec.rb`に追加
	 - nameに日本語が使用できる
	 - nameに英数字が使用できる
	 - nameにハイフンが使用できる
	 - nameにカッコが使用できる
	 - nameに中点が使用できる
	 - 特殊記号を使用しているため無効

## テスト／完了確認
 - [x] `Family`のモデルスペックのテストが全て通ることを確認した