### PR TITLE
Fix: #233 子どもの情報を削除する際、紐づいた日記が存在する場合は削除できないよう変更

### DIFF
--- a/app/controllers/families/children_controller.rb
+++ b/app/controllers/families/children_controller.rb
@@ -32,7 +32,7 @@ module Families
     end
 
     def destroy
-      return redirect_to family_children_path(@family), alert: '子どもに紐づいた日記がある場合は、子どもの情報を削除できません。' if @child.diaries.count.positive?
+      return redirect_to family_children_path(@family), alert: '子どもに紐づいた日記がある場合は、子どもの情報を削除できません。', status: :see_other if @child.diaries.exists?
 
       @child.destroy
       redirect_to family_path(@family), notice: "子どもの情報を削除しました", status: :see_other

--- a/app/controllers/families/children_controller.rb
+++ b/app/controllers/families/children_controller.rb
@@ -25,13 +25,14 @@ module Families
 
     def update
       if @child.update(child_params)
-        redirect_to family_path(@family), notice: "子どもの情報を更新しました", status: :see_other
+        redirect_to family_children_path(@family), notice: "子どもの情報を更新しました", status: :see_other
       else
         render :edit, status: :unprocessable_entity
       end
     end
 
     def destroy
+      return redirect_to family_children_path(@family), alert: '子どもに紐づいた日記がある場合は、子どもの情報を削除できません。' if @child.diaries.count.positive?
       @child.destroy
       redirect_to family_path(@family), notice: "子どもの情報を削除しました", status: :see_other
     end

--- a/app/controllers/families/children_controller.rb
+++ b/app/controllers/families/children_controller.rb
@@ -33,6 +33,7 @@ module Families
 
     def destroy
       return redirect_to family_children_path(@family), alert: '子どもに紐づいた日記がある場合は、子どもの情報を削除できません。' if @child.diaries.count.positive?
+
       @child.destroy
       redirect_to family_path(@family), notice: "子どもの情報を削除しました", status: :see_other
     end

--- a/app/controllers/families/families_controller.rb
+++ b/app/controllers/families/families_controller.rb
@@ -45,7 +45,7 @@ module Families
 
     def destroy
       # 条件1：家族のメンバーが自分（管理者）以外にいないこと
-      return redirect_to family_path(@family), alert: '自分以外のメンバーがいる場合は家族を削除できません。' if @family.users.count.positive?
+      return redirect_to family_path(@family), alert: '自分以外のメンバーがいる場合は家族を削除できません。' if @family.users.count > 1
 
       # 条件2：子どもの情報が一つも存在していないこと
       return redirect_to family_path(@family), alert: '子どもの情報がある場合は家族を削除できません。' if @family.children.count.positive?

--- a/app/controllers/families/families_controller.rb
+++ b/app/controllers/families/families_controller.rb
@@ -48,7 +48,7 @@ module Families
       return redirect_to family_path(@family), alert: '自分以外のメンバーがいる場合は家族を削除できません。' if @family.users.count > 1
 
       # 条件2：子どもの情報が一つも存在していないこと
-      return redirect_to family_path(@family), alert: '子どもの情報がある場合は家族を削除できません。' if @family.children.count.positive?
+      return redirect_to family_path(@family), alert: '子どもの情報がある場合は家族を削除できません。' if @family.children.exists?
 
       ActiveRecord::Base.transaction do
         # 1. ユーザーの family_id を空にする

--- a/app/controllers/families/families_controller.rb
+++ b/app/controllers/families/families_controller.rb
@@ -45,7 +45,7 @@ module Families
 
     def destroy
       # 条件1：家族のメンバーが自分（管理者）以外にいないこと
-      return redirect_to family_path(@family), alert: '自分以外のメンバーがいる場合は家族を削除できません。' if @family.users.count > 1
+      return redirect_to family_path(@family), alert: '自分以外のメンバーがいる場合は家族を削除できません。' if @family.users.count.positive?
 
       # 条件2：子どもの情報が一つも存在していないこと
       return redirect_to family_path(@family), alert: '子どもの情報がある場合は家族を削除できません。' if @family.children.count.positive?


### PR DESCRIPTION
## 概要
その子に紐づいた日記が1件でも存在する場合は、子どもの情報を削除できないようにした

## 関連issue
#233 

## やったこと
 - `app/controllers/families/children_controller.rb`の`destroy`アクションに「その子に紐づいた日記が1件でも存在する場合は削除できず、エラーメッセージを表示する」処理を追加

## テスト／完了確認
 - [x] 1件でも紐づいている日記が存在する場合、子どもの情報を削除できないことを確認した
 - [x] 紐づいている日記が存在していない場合、子どもの情報を削除できることを確認した