### PR TITLE
Hotfix: タイムゾーン設定の修正

### DIFF
--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -32,7 +32,7 @@ class Diary < ApplicationRecord
 
   def date_cannot_be_in_the_future
     return if date.blank?
-    return unless date > Date.today
+    return unless date > Date.current
 
     errors.add(:date, "を未来の日にすることはできません")
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,7 +68,7 @@ class User < ApplicationRecord
 
   def birthday_cannot_be_in_the_future
     return if birthday.blank?
-    return unless birthday > Date.today
+    return unless birthday > Date.current
 
     errors.add(:birthday, "を未来の日付にすることはできません")
   end

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -62,10 +62,10 @@
           >
             <!-- Date link positioned at the top-center of the cell -->
             <div class="text-center pt-1 relative inline-flex items-center justify-center">
-              <% if day == Date.today %>
+              <% if day == Date.current %>
                 <div class="absolute w-6 h-6 bg-rose-200/70 rounded-full blur-xs"></div>
               <% end %>
-              <%= link_to day.day, date_index_diaries_path(date: day), class: "text-base font-bold transition-colors text-amber-800 hover:text-rose-600 #{day == Date.today ? 'relative': ''}" %>
+              <%= link_to day.day, date_index_diaries_path(date: day), class: "text-base font-bold transition-colors text-amber-800 hover:text-rose-600 #{day == Date.current ? 'relative': ''}" %>
             </div>
             <!-- Scrollable container with no-scrollbar class to hide ugly browser scrollbars -->
             <div class="flex-grow overflow-y-auto no-scrollbar">

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ module App
     config.load_defaults 7.1
 
     config.time_zone = "Asia/Tokyo"
-    config.active_record.default_timezone = :local
+    config.active_record.default_timezone = :utc
     config.i18n.default_locale = :ja
 
     config.beginning_of_week = :sunday


### PR DESCRIPTION
## 概要
タイムゾーン設定を修正し、「今日の日付」が日本時間基準で取得されるように変更した

## 関連issue
#237 

## やったこと
 - `config/application.rb`内の`config.active_record.default_timezone`を`:utc`に変更
 - 日本時間基準で取得するために、`Date.today`としていた部分を`Date.current`に変更

## テスト／完了確認
 - [x] Railsコンソールで`Rails.config.active_record.default_timezone`が`:utc`になっていることを確認した
 - [x] コンソールで`Date.current`や`Time.current`を実行すると日本時間の日時になっていることを確認した
 - [x] 午前0～9時までの時間帯に、日付を今日のものに設定して日記の投稿を試み「未来の日付を設定することはできません」と表示されないことを確認した
 - [x] 午前0～9時までの時間帯にカレンダーをチェックし、きちんと今日の日付が色付けされているかを確認した