### PR TITLE
Release v.1.0.1: タイムゾーン設定と今日の日付基準を日本時間に修正

### DIFF
--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -32,7 +32,7 @@ class Diary < ApplicationRecord
 
   def date_cannot_be_in_the_future
     return if date.blank?
-    return unless date > Date.today
+    return unless date > Date.current
 
     errors.add(:date, "を未来の日にすることはできません")
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,7 +68,7 @@ class User < ApplicationRecord
 
   def birthday_cannot_be_in_the_future
     return if birthday.blank?
-    return unless birthday > Date.today
+    return unless birthday > Date.current
 
     errors.add(:birthday, "を未来の日付にすることはできません")
   end

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -62,10 +62,10 @@
           >
             <!-- Date link positioned at the top-center of the cell -->
             <div class="text-center pt-1 relative inline-flex items-center justify-center">
-              <% if day == Date.today %>
+              <% if day == Date.current %>
                 <div class="absolute w-6 h-6 bg-rose-200/70 rounded-full blur-xs"></div>
               <% end %>
-              <%= link_to day.day, date_index_diaries_path(date: day), class: "text-base font-bold transition-colors text-amber-800 hover:text-rose-600 #{day == Date.today ? 'relative': ''}" %>
+              <%= link_to day.day, date_index_diaries_path(date: day), class: "text-base font-bold transition-colors text-amber-800 hover:text-rose-600 #{day == Date.current ? 'relative': ''}" %>
             </div>
             <!-- Scrollable container with no-scrollbar class to hide ugly browser scrollbars -->
             <div class="flex-grow overflow-y-auto no-scrollbar">

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ module App
     config.load_defaults 7.1
 
     config.time_zone = "Asia/Tokyo"
-    config.active_record.default_timezone = :local
+    config.active_record.default_timezone = :utc
     config.i18n.default_locale = :ja
 
     config.beginning_of_week = :sunday


### PR DESCRIPTION
## リリース概要
v1.0.1 リリース
タイムゾーン設定と「今日の日付」の基準を日本時間に修正

## 含まれる変更
- タイムゾーン設定の修正
- 「今日の日付」の基準を日本時間に修正

## 動作確認済み項目
- [x] ユーザー登録時の誕生日や日記投稿の際に「未来の日付を設定できない」基準が、日本時間の「今日の日付」になっていることを確認
- [x] カレンダー表示画面で、日本時間基準の「今日の日付」にスタイルが適用されていることを確認

## 関連PR
#238 